### PR TITLE
Stub generator fixes

### DIFF
--- a/wasm-rpc-stubgen/src/lib.rs
+++ b/wasm-rpc-stubgen/src/lib.rs
@@ -37,7 +37,7 @@ use tempdir::TempDir;
 use wasm_compose::config::Dependency;
 
 #[derive(Parser, Debug)]
-#[command(name = "wasm-rpc-stubgen")]
+#[command(name = "wasm-rpc-stubgen", version)]
 #[command(bin_name = "wasm-rpc-stubgen")]
 pub enum Command {
     /// Generate a Rust RPC stub crate for a WASM component
@@ -272,13 +272,13 @@ pub fn add_stub_dependency(args: AddStubDependencyArgs) -> anyhow::Result<()> {
 
     if let Some(target_parent) = args.dest_wit_root.parent() {
         let target_cargo_toml = target_parent.join("Cargo.toml");
-        if target_cargo_toml.exists()
-            && target_cargo_toml.is_file()
-            && cargo::is_cargo_component_toml(&target_cargo_toml).is_ok()
-        {
+        if target_cargo_toml.exists() && target_cargo_toml.is_file() {
             if !args.update_cargo_toml {
                 eprintln!("Warning: the newly copied dependencies have to be added to {}. Use the --update-cargo-toml flag to update it automatically.", target_cargo_toml.to_string_lossy());
             } else {
+                cargo::is_cargo_component_toml(&target_cargo_toml).context(format!(
+                    "The file {target_cargo_toml:?} is not a valid cargo-component project"
+                ))?;
                 let mut names = Vec::new();
                 for action in actions {
                     names.push(action.get_dep_dir_name()?);

--- a/wasm-rpc-stubgen/src/rust.rs
+++ b/wasm-rpc-stubgen/src/rust.rs
@@ -769,7 +769,7 @@ fn wit_enum_value_builder(
 
     let mut cases = Vec::new();
     for (n, case) in enum_def.cases.iter().enumerate() {
-        let case_name = Ident::new(&case.name.to_shouty_snake_case(), Span::call_site());
+        let case_name = Ident::new(&case.name.to_upper_camel_case(), Span::call_site());
         let case_idx = n as u32;
         cases.push(quote! {
             #enum_type::#case_name => #case_idx
@@ -1074,7 +1074,7 @@ fn extract_from_enum_value(
 
     let mut case_extractors = Vec::new();
     for (n, case) in enum_def.cases.iter().enumerate() {
-        let case_name = Ident::new(&case.name.to_shouty_snake_case(), Span::call_site());
+        let case_name = Ident::new(&case.name.to_upper_camel_case(), Span::call_site());
         let case_idx = n as u32;
         case_extractors.push(quote! {
             #case_idx => #enum_type::#case_name


### PR DESCRIPTION
Fixes several issues found in the stub generator:
- Resolves #20 
- Resolves #21 
- Fixed error reporting when the `Cargo.toml` to be modified by `add-stub-dependency` is invalid
- Made this check more tolerant to missing keys
- Fixed the enum names in the generated stub code
- Enabled the version CLI command