### PR TITLE
Update repository field in Cargo.toml

### DIFF
--- a/wasm-rpc-stubgen/Cargo.toml
+++ b/wasm-rpc-stubgen/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://golem.cloud"
+repository = "https://github.com/golemcloud/wasm-rpc"
 description = "Golem WASM RPC stub generator"
 
 [lib]

--- a/wasm-rpc/Cargo.toml
+++ b/wasm-rpc/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://golem.cloud"
+repository = "https://github.com/golemcloud/wasm-rpc"
 description = "Golem WASM RPC support library"
 
 include = []


### PR DESCRIPTION
Change `homepage` key to instead use the [repository](https://rust-digger.code-maven.com/about-repository) key for correctly labeling/pointing to the GitHub repo.

This makes location of the source code easier to see Crates.io. 🙂

---

(Found two more! - I will stop bothering you after this... 😄 )