### PR TITLE
Fix copy_with_files step

### DIFF
--- a/wasm-rpc-stubgen/src/wit.rs
+++ b/wasm-rpc-stubgen/src/wit.rs
@@ -536,15 +536,10 @@ pub fn copy_wit_files(def: &StubDefinition) -> anyhow::Result<()> {
                 fs::write(&dest, new_data.to_string())?;
             }
         } else {
-            println!("Copying package {}", unresolved.name);
+            if unresolved.name.to_string() != stub_package_name {
+                println!("Copying package {}", unresolved.name);
 
-            for source in unresolved.source_files() {
-                let parsed = UnresolvedPackage::parse_path(source)?;
-                let stub_package_name = format!("{}-stub", def.root_package_name);
-
-                if parsed.name.to_string() == stub_package_name {
-                    println!("Skipping copying stub package {}", stub_package_name);
-                } else {
+                for source in unresolved.source_files() {
                     let relative = source.strip_prefix(&def.source_wit_root)?;
                     let dest = dest_wit_root.clone().join(relative);
                     println!(
@@ -555,6 +550,8 @@ pub fn copy_wit_files(def: &StubDefinition) -> anyhow::Result<()> {
                     fs::create_dir_all(dest.parent().unwrap())?;
                     fs::copy(source, &dest)?;
                 }
+            } else {
+                println!("Skipping copying stub package {}", stub_package_name);
             }
         }
     }

--- a/wasm-rpc-stubgen/src/wit.rs
+++ b/wasm-rpc-stubgen/src/wit.rs
@@ -535,24 +535,22 @@ pub fn copy_wit_files(def: &StubDefinition) -> anyhow::Result<()> {
                 fs::create_dir_all(dest.parent().unwrap())?;
                 fs::write(&dest, new_data.to_string())?;
             }
-        } else {
-            if unresolved.name.to_string() != stub_package_name {
-                println!("Copying package {}", unresolved.name);
+        } else if unresolved.name.to_string() != stub_package_name {
+            println!("Copying package {}", unresolved.name);
 
-                for source in unresolved.source_files() {
-                    let relative = source.strip_prefix(&def.source_wit_root)?;
-                    let dest = dest_wit_root.clone().join(relative);
-                    println!(
-                        "  .. {} to {}",
-                        source.to_string_lossy(),
-                        dest.to_string_lossy()
-                    );
-                    fs::create_dir_all(dest.parent().unwrap())?;
-                    fs::copy(source, &dest)?;
-                }
-            } else {
-                println!("Skipping copying stub package {}", stub_package_name);
+            for source in unresolved.source_files() {
+                let relative = source.strip_prefix(&def.source_wit_root)?;
+                let dest = dest_wit_root.clone().join(relative);
+                println!(
+                    "  .. {} to {}",
+                    source.to_string_lossy(),
+                    dest.to_string_lossy()
+                );
+                fs::create_dir_all(dest.parent().unwrap())?;
+                fs::copy(source, &dest)?;
             }
+        } else {
+            println!("Skipping copying stub package {}", stub_package_name);
         }
     }
     let wasm_rpc_root = dest_wit_root.join(Path::new("deps/wasm-rpc"));


### PR DESCRIPTION
We cannot (and don't have to) parse individual files of a package as they together form a package. 