### PR TITLE
Make type_annotated_value a proto type

### DIFF
--- a/wasm-rpc/build.rs
+++ b/wasm-rpc/build.rs
@@ -12,6 +12,7 @@ fn main() -> Result<()> {
             "proto/wasm/rpc/type.proto",
             "proto/wasm/rpc/val.proto",
             "proto/wasm/rpc/witvalue.proto",
+            "proto/wasm/rpc/type_annotated_value.proto",
         ],
         &["proto/"],
     )?;

--- a/wasm-rpc/proto/wasm/rpc/type_annotated_value.proto
+++ b/wasm-rpc/proto/wasm/rpc/type_annotated_value.proto
@@ -1,0 +1,87 @@
+syntax = "proto3";
+
+package wasm.rpc;
+import "wasm/rpc/type.proto";
+
+message TypeAnnotatedValue {
+    oneof type_annotated_value {
+        bool bool = 1;
+        int32 s8 = 2;
+        uint32 u8 = 3;
+        int32 s16 = 4;
+        uint32 u16 = 5;
+        int32 s32 = 6;
+        uint32 u32 = 7;
+        int64 s64 = 8;
+        uint64 u64 = 9;
+        float f32 = 10;
+        double f64 = 11;
+        int32 char = 12;
+        string str = 13;
+        TypedList list = 14;
+        TypedTuple tuple = 15;
+        TypedRecord record = 16;
+        TypedFlags flags = 17;
+        TypedVariant variant = 18;
+        TypedEnum enum = 19;
+        TypedOption option = 20;
+        TypedResult result = 21;
+        TypedHandle handle = 22;
+    }
+}
+
+message TypedList {
+    Type typ = 1;
+    repeated TypeAnnotatedValue values = 2;
+}
+
+message TypedTuple {
+    repeated Type typ = 1;
+    repeated TypeAnnotatedValue value = 2;
+}
+
+message TypedRecord {
+    repeated NameTypePair typ = 1;
+    repeated NameValuePair value = 2;
+}
+
+message TypedFlags {
+    repeated string typ = 1;
+    repeated string values = 2;
+}
+
+message TypedVariant {
+    TypeVariant typ = 1;
+    string case_name = 2;
+    TypeAnnotatedValue case_value = 3;
+}
+
+message TypedEnum {
+    repeated string typ = 1;
+    string value = 2;
+}
+
+message TypedOption {
+    Type typ = 1;
+    optional TypeAnnotatedValue value = 2;
+}
+
+message TypedResult {
+    Type ok = 1;
+    Type error = 2;
+    oneof result_value {
+        TypeAnnotatedValue ok_value = 3;
+        TypeAnnotatedValue error_value = 4;
+    }
+}
+
+message TypedHandle {
+    TypeHandle typ = 1;
+    string uri = 2;
+    uint64 resource_id = 3;
+}
+
+message NameValuePair {
+    string name = 1;
+    TypeAnnotatedValue value = 2;
+}

--- a/wasm-rpc/src/json.rs
+++ b/wasm-rpc/src/json.rs
@@ -12,6 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::protobuf::type_annotated_value::TypeAnnotatedValue;
+use crate::protobuf::typed_result::ResultValue;
+use crate::protobuf::{
+    NameOptionTypePair, NameTypePair, NameValuePair, TypeHandle, TypeVariant, TypedEnum,
+    TypedFlags, TypedHandle, TypedList, TypedOption, TypedRecord, TypedTuple, TypedVariant,
+};
+use crate::protobuf::{TypeAnnotatedValue as RootTypeAnnotatedValue, TypedResult};
+use crate::{type_annotated_value, Value};
 use bigdecimal::{BigDecimal, FromPrimitive, ToPrimitive};
 use golem_wasm_ast::analysis::{
     AnalysedFunctionParameter, AnalysedFunctionResult, AnalysedResourceId, AnalysedResourceMode,
@@ -19,9 +27,8 @@ use golem_wasm_ast::analysis::{
 };
 use serde_json::{Number, Value as JsonValue};
 use std::collections::HashMap;
+use std::ops::Deref;
 use std::str::FromStr;
-
-use crate::{TypeAnnotatedValue, Uri, Value};
 
 pub fn function_parameters(
     value: &JsonValue,
@@ -104,12 +111,13 @@ pub fn function_result_typed(
         let mut results = vec![];
         let mut errors = vec![];
 
-        for (value, expected) in values.into_iter().zip(expected_types.iter()) {
-            let result = TypeAnnotatedValue::from_value(&value, &expected.typ);
+        for (value, expected) in values.iter().zip(expected_types.iter()) {
+            let analysed_typ = &expected.typ;
+            let result = type_annotated_value::create(value, analysed_typ);
 
             match result {
                 Ok(value) => {
-                    results.push((value, expected.typ.clone()));
+                    results.push((value, analysed_typ.into()));
                 }
                 Err(err) => errors.extend(err),
             }
@@ -118,12 +126,24 @@ pub fn function_result_typed(
         let all_without_names = expected_types.iter().all(|t| t.name.is_none());
 
         if all_without_names {
-            Ok(TypeAnnotatedValue::Tuple {
-                typ: results.iter().map(|(_, typ)| typ.clone()).collect(),
-                value: results.into_iter().map(|(v, _)| v).collect(),
-            })
+            let mut types = vec![];
+            let mut values = vec![];
+
+            for (value, typ) in results {
+                types.push(typ);
+                values.push(RootTypeAnnotatedValue {
+                    type_annotated_value: Some(value),
+                });
+            }
+
+            let tuple = TypedTuple {
+                typ: types,
+                value: values,
+            };
+
+            Ok(TypeAnnotatedValue::Tuple(tuple))
         } else {
-            let mut named_typs: Vec<(String, AnalysedType)> = vec![];
+            let mut named_typs: Vec<(String, crate::protobuf::Type)> = vec![];
             let mut named_values: Vec<(String, TypeAnnotatedValue)> = vec![];
 
             for (index, ((typed_value, typ), expected)) in
@@ -139,10 +159,26 @@ pub fn function_result_typed(
                 named_values.push((name, typed_value));
             }
 
-            Ok(TypeAnnotatedValue::Record {
-                typ: named_typs,
-                value: named_values,
-            })
+            let record = TypedRecord {
+                typ: named_typs
+                    .iter()
+                    .map(|(name, typ)| NameTypePair {
+                        name: name.clone(),
+                        typ: Some(typ.clone()),
+                    })
+                    .collect(),
+                value: named_values
+                    .iter()
+                    .map(|(name, value)| NameValuePair {
+                        name: name.clone(),
+                        value: Some(RootTypeAnnotatedValue {
+                            type_annotated_value: Some(value.clone()),
+                        }),
+                    })
+                    .collect(),
+            };
+
+            Ok(TypeAnnotatedValue::Record(record))
         }
     }
 }
@@ -198,7 +234,7 @@ fn get_s8(json: &JsonValue) -> Result<TypeAnnotatedValue, Vec<String>> {
         BigDecimal::from_i8(i8::MIN).expect("Failed to convert i8::MIN to BigDecimal"),
         BigDecimal::from_i8(i8::MAX).expect("Failed to convert i8::MAX to BigDecimal"),
     )
-    .map(|num| TypeAnnotatedValue::S8(num.to_i8().expect("Failed to convert BigDecimal to i8")))
+    .map(|num| TypeAnnotatedValue::S8(num.to_i32().expect("Failed to convert BigDecimal to i8")))
 }
 
 fn get_u8(json: &JsonValue) -> Result<TypeAnnotatedValue, Vec<String>> {
@@ -207,7 +243,7 @@ fn get_u8(json: &JsonValue) -> Result<TypeAnnotatedValue, Vec<String>> {
         BigDecimal::from_u8(u8::MIN).expect("Failed to convert u8::MIN to BigDecimal"),
         BigDecimal::from_u8(u8::MAX).expect("Failed to convert u8::MAX to BigDecimal"),
     )
-    .map(|num| TypeAnnotatedValue::U8(num.to_u8().expect("Failed to convert BigDecimal to u8")))
+    .map(|num| TypeAnnotatedValue::U8(num.to_u32().expect("Failed to convert BigDecimal to u8")))
 }
 
 fn get_s16(json: &JsonValue) -> Result<TypeAnnotatedValue, Vec<String>> {
@@ -216,7 +252,7 @@ fn get_s16(json: &JsonValue) -> Result<TypeAnnotatedValue, Vec<String>> {
         BigDecimal::from_i16(i16::MIN).expect("Failed to convert i16::MIN to BigDecimal"),
         BigDecimal::from_i16(i16::MAX).expect("Failed to convert i16::MAX to BigDecimal"),
     )
-    .map(|num| TypeAnnotatedValue::S16(num.to_i16().expect("Failed to convert BigDecimal to i16")))
+    .map(|num| TypeAnnotatedValue::S16(num.to_i32().expect("Failed to convert BigDecimal to i16")))
 }
 
 fn get_u16(json: &JsonValue) -> Result<TypeAnnotatedValue, Vec<String>> {
@@ -225,7 +261,7 @@ fn get_u16(json: &JsonValue) -> Result<TypeAnnotatedValue, Vec<String>> {
         BigDecimal::from_u16(u16::MIN).expect("Failed to convert u16::MIN to BigDecimal"),
         BigDecimal::from_u16(u16::MAX).expect("Failed to convert u16::MAX to BigDecimal"),
     )
-    .map(|num| TypeAnnotatedValue::U16(num.to_u16().expect("Failed to convert BigDecimal to u16")))
+    .map(|num| TypeAnnotatedValue::U16(num.to_u32().expect("Failed to convert BigDecimal to u16")))
 }
 
 fn get_s32(json: &JsonValue) -> Result<TypeAnnotatedValue, Vec<String>> {
@@ -296,12 +332,7 @@ fn get_char(json: &JsonValue) -> Result<TypeAnnotatedValue, Vec<String>> {
                 num_u64
             )])
         } else {
-            char::from_u32(num_u64 as u32)
-                .ok_or(vec![format!(
-                    "The value {} is not a valid unicode character",
-                    num_u64
-                )])
-                .map(TypeAnnotatedValue::Chr)
+            Ok(TypeAnnotatedValue::Char(num_u64 as i32))
         }
     } else {
         let type_description = type_description(json);
@@ -339,11 +370,18 @@ fn get_tuple(
         }
     }
 
+    let tuple = TypedTuple {
+        typ: types.iter().map(|t| t.into()).collect(),
+        value: vals
+            .iter()
+            .map(|v| RootTypeAnnotatedValue {
+                type_annotated_value: Some(v.clone()),
+            })
+            .collect(),
+    };
+
     if errors.is_empty() {
-        Ok(TypeAnnotatedValue::Tuple {
-            typ: types.to_vec(),
-            value: vals,
-        })
+        Ok(TypeAnnotatedValue::Tuple(tuple))
     } else {
         Err(errors)
     }
@@ -354,17 +392,25 @@ fn get_option(
     tpe: &AnalysedType,
 ) -> Result<TypeAnnotatedValue, Vec<String>> {
     match input_json.as_null() {
-        Some(_) => Ok(TypeAnnotatedValue::Option {
-            typ: tpe.clone(),
-            value: None,
-        }),
+        Some(_) => {
+            let option = TypedOption {
+                typ: Some(tpe.into()),
+                value: None,
+            };
 
-        None => {
-            get_typed_value_from_json(input_json, tpe).map(|result| TypeAnnotatedValue::Option {
-                typ: tpe.clone(),
-                value: Some(Box::new(result)),
-            })
+            Ok(TypeAnnotatedValue::Option(Box::new(option)))
         }
+
+        None => get_typed_value_from_json(input_json, tpe).map(|result| {
+            let option = TypedOption {
+                typ: Some(tpe.into()),
+                value: Some(Box::new(RootTypeAnnotatedValue {
+                    type_annotated_value: Some(result),
+                })),
+            };
+
+            TypeAnnotatedValue::Option(Box::new(option))
+        }),
     }
 }
 
@@ -383,11 +429,18 @@ fn get_list(input_json: &JsonValue, tpe: &AnalysedType) -> Result<TypeAnnotatedV
         }
     }
 
+    let list = TypedList {
+        typ: Some(tpe.into()),
+        values: vals
+            .iter()
+            .map(|v| RootTypeAnnotatedValue {
+                type_annotated_value: Some(v.clone()),
+            })
+            .collect(),
+    };
+
     if errors.is_empty() {
-        Ok(TypeAnnotatedValue::List {
-            typ: tpe.clone(),
-            values: vals,
-        })
+        Ok(TypeAnnotatedValue::List(list))
     } else {
         Err(errors)
     }
@@ -398,11 +451,12 @@ fn get_enum(input_json: &JsonValue, names: &[String]) -> Result<TypeAnnotatedVal
         .as_str()
         .ok_or(vec![format!("Input {} is not string", input_json)])?;
 
+    let enum_value = TypedEnum {
+        typ: names.to_vec(),
+        value: input_enum_value.to_string(),
+    };
     if names.contains(&input_enum_value.to_string()) {
-        Ok(TypeAnnotatedValue::Enum {
-            typ: names.to_vec(),
-            value: input_enum_value.to_string(),
-        })
+        Ok(TypeAnnotatedValue::Enum(enum_value))
     } else {
         Err(vec![format!(
             "Invalid input {}. Valid values are {}",
@@ -434,17 +488,41 @@ fn get_result(
     }
 
     match input_json.get("ok") {
-        Some(value) => Ok(TypeAnnotatedValue::Result {
-            ok: ok_type.clone(),
-            error: err_type.clone(),
-            value: Ok(validate(ok_type, value)?),
-        }),
+        Some(value) => {
+            let value = validate(ok_type, value)?;
+
+            let result_value = value.map(|value| {
+                ResultValue::OkValue(Box::new(RootTypeAnnotatedValue {
+                    type_annotated_value: Some(value.deref().clone()),
+                }))
+            });
+
+            let typed_result = TypedResult {
+                ok: ok_type.clone().map(|x| x.deref().into()),
+                error: err_type.clone().map(|x| x.deref().into()),
+                result_value,
+            };
+
+            Ok(TypeAnnotatedValue::Result(Box::new(typed_result)))
+        }
         None => match input_json.get("err") {
-            Some(value) => Ok(TypeAnnotatedValue::Result {
-                ok: ok_type.clone(),
-                error: err_type.clone(),
-                value: Err(validate(err_type, value)?),
-            }),
+            Some(value) => {
+                let value = validate(err_type, value)?;
+
+                let result_value = value.map(|value| {
+                    ResultValue::ErrorValue(Box::new(RootTypeAnnotatedValue {
+                        type_annotated_value: Some(value.deref().clone()),
+                    }))
+                });
+
+                let typed_result = TypedResult {
+                    ok: ok_type.clone().map(|x| x.deref().into()),
+                    error: err_type.clone().map(|x| x.deref().into()),
+                    result_value,
+                };
+
+                Ok(TypeAnnotatedValue::Result(Box::new(typed_result)))
+            }
             None => Err(vec![
                 "Failed to retrieve either ok value or err value".to_string()
             ]),
@@ -477,23 +555,44 @@ fn get_record(
             }
         } else {
             match tpe {
-                AnalysedType::Option(_) => vals.push((
-                    name.clone(),
-                    TypeAnnotatedValue::Option {
-                        typ: tpe.clone(),
+                AnalysedType::Option(_) => {
+                    let option = TypedOption {
+                        typ: Some(tpe.into()),
                         value: None,
-                    },
-                )),
+                    };
+
+                    vals.push((name.clone(), TypeAnnotatedValue::Option(Box::new(option))))
+                }
                 _ => errors.push(format!("Key '{}' not found in json_map", name)),
             }
         }
     }
 
     if errors.is_empty() {
-        Ok(TypeAnnotatedValue::Record {
-            typ: name_type_pairs.to_vec(),
-            value: vals,
-        })
+        let name_type_pairs = name_type_pairs
+            .iter()
+            .map(|(name, tpe)| NameTypePair {
+                name: name.clone(),
+                typ: Some(tpe.into()),
+            })
+            .collect::<Vec<_>>();
+
+        let name_value_pairs = vals
+            .iter()
+            .map(|(name, value)| NameValuePair {
+                name: name.clone(),
+                value: Some(RootTypeAnnotatedValue {
+                    type_annotated_value: Some(value.clone()),
+                }),
+            })
+            .collect::<Vec<_>>();
+
+        let record = TypedRecord {
+            typ: name_type_pairs,
+            value: name_value_pairs,
+        };
+
+        Ok(TypeAnnotatedValue::Record(record))
     } else {
         Err(errors)
     }
@@ -530,10 +629,11 @@ fn get_flag(input_json: &JsonValue, names: &[String]) -> Result<TypeAnnotatedVal
     }
 
     if errors.is_empty() {
-        Ok(TypeAnnotatedValue::Flags {
+        let flags = TypedFlags {
             typ: names.to_vec(),
             values: vals,
-        })
+        };
+        Ok(TypeAnnotatedValue::Flags(flags))
     } else {
         Err(errors)
     }
@@ -561,17 +661,42 @@ fn get_variant(
 
     match possible_mapping_indexed.get(key) {
         Some(Some(tpe)) => {
-            get_typed_value_from_json(json, tpe).map(|result| TypeAnnotatedValue::Variant {
-                typ: types.to_vec(),
+            let result = get_typed_value_from_json(json, tpe)?;
+            let variant = TypedVariant {
+                typ: Some(TypeVariant {
+                    cases: types
+                        .iter()
+                        .map(|(name, t)| NameOptionTypePair {
+                            name: name.clone(),
+                            typ: t.as_ref().map(|t| t.into()),
+                        })
+                        .collect(),
+                }),
                 case_name: key.clone(),
-                case_value: Some(Box::new(result)),
-            })
+                case_value: Some(Box::new(RootTypeAnnotatedValue {
+                    type_annotated_value: Some(result),
+                })),
+            };
+
+            Ok(TypeAnnotatedValue::Variant(Box::new(variant)))
         }
-        Some(None) if json.is_null() => Ok(TypeAnnotatedValue::Variant {
-            typ: types.to_vec(),
-            case_name: key.clone(),
-            case_value: None,
-        }),
+        Some(None) if json.is_null() => {
+            let variant = TypedVariant {
+                typ: Some(TypeVariant {
+                    cases: types
+                        .iter()
+                        .map(|(name, t)| NameOptionTypePair {
+                            name: name.clone(),
+                            typ: t.as_ref().map(|t| t.into()),
+                        })
+                        .collect(),
+                }),
+                case_name: key.clone(),
+                case_value: None,
+            };
+
+            Ok(TypeAnnotatedValue::Variant(Box::new(variant)))
+        }
         Some(None) => Err(vec![format!("Unit variant {key} has non-null JSON value")]),
         None => Err(vec![format!("Unknown key {key} in the variant")]),
     }
@@ -590,7 +715,19 @@ fn get_handle(
                 match u64::from_str(parts[parts.len() - 1]) {
                     Ok(resource_id) => {
                         let uri = parts[0..(parts.len() - 1)].join("/");
-                        Ok(TypeAnnotatedValue::Handle { id, resource_mode, uri: Uri { value: uri }, resource_id })
+
+                        let handle = TypedHandle {
+                            typ: Some(TypeHandle {
+                                resource_id: id.value,
+                                mode: match resource_mode {
+                                    AnalysedResourceMode::Owned => 1,
+                                    AnalysedResourceMode::Borrowed => 2,
+                                },
+                            }),
+                            uri,
+                            resource_id
+                        };
+                        Ok(TypeAnnotatedValue::Handle(handle))
                     }
                     Err(err) => {
                         Err(vec![format!("Failed to parse resource-id section of the handle value: {}", err)])
@@ -678,7 +815,7 @@ fn get_u64(value: &JsonValue) -> Result<TypeAnnotatedValue, Vec<String>> {
 pub fn get_json_from_typed_value(typed_value: &TypeAnnotatedValue) -> JsonValue {
     match typed_value {
         TypeAnnotatedValue::Bool(bool) => JsonValue::Bool(*bool),
-        TypeAnnotatedValue::Flags { typ: _, values } => JsonValue::Array(
+        TypeAnnotatedValue::Flags(TypedFlags { typ: _, values }) => JsonValue::Array(
             values
                 .iter()
                 .map(|x| JsonValue::String(x.clone()))
@@ -696,90 +833,101 @@ pub fn get_json_from_typed_value(typed_value: &TypeAnnotatedValue) -> JsonValue 
             JsonValue::Number(Number::from_f64(*value as f64).unwrap())
         }
         TypeAnnotatedValue::F64(value) => JsonValue::Number(Number::from_f64(*value).unwrap()),
-        TypeAnnotatedValue::Chr(value) => JsonValue::Number(Number::from(*value as u32)),
+        TypeAnnotatedValue::Char(value) => JsonValue::Number(Number::from(*value as u32)),
         TypeAnnotatedValue::Str(value) => JsonValue::String(value.clone()),
-        TypeAnnotatedValue::Enum { typ: _, value } => JsonValue::String(value.clone()),
-        TypeAnnotatedValue::Option { typ: _, value } => match value {
-            Some(value) => get_json_from_typed_value(value),
+        TypeAnnotatedValue::Enum(TypedEnum { typ: _, value }) => JsonValue::String(value.clone()),
+        TypeAnnotatedValue::Option(option) => match &option.value {
+            Some(value) => get_json_from_typed_value(&value.clone().type_annotated_value.unwrap()),
             None => JsonValue::Null,
         },
-        TypeAnnotatedValue::Tuple { typ: _, value } => {
-            let values: Vec<serde_json::Value> =
-                value.iter().map(get_json_from_typed_value).collect();
+        TypeAnnotatedValue::Tuple(TypedTuple { typ: _, value }) => {
+            let values: Vec<serde_json::Value> = value
+                .iter()
+                .map(|v| get_json_from_typed_value(&v.type_annotated_value.clone().unwrap()))
+                .collect();
             JsonValue::Array(values)
         }
-        TypeAnnotatedValue::List { typ: _, values } => {
-            let values: Vec<serde_json::Value> =
-                values.iter().map(get_json_from_typed_value).collect();
+        TypeAnnotatedValue::List(TypedList { typ: _, values }) => {
+            let values: Vec<serde_json::Value> = values
+                .iter()
+                .map(|v| get_json_from_typed_value(&v.type_annotated_value.clone().unwrap()))
+                .collect();
             JsonValue::Array(values)
         }
 
-        TypeAnnotatedValue::Record { typ: _, value } => {
+        TypeAnnotatedValue::Record(TypedRecord { typ: _, value }) => {
             let mut map = serde_json::Map::new();
-            for (key, value) in value {
-                map.insert(key.clone(), get_json_from_typed_value(value));
+            for name_value in value {
+                map.insert(
+                    name_value.name.clone(),
+                    get_json_from_typed_value(
+                        &name_value
+                            .value
+                            .clone()
+                            .unwrap()
+                            .type_annotated_value
+                            .unwrap(),
+                    ),
+                );
             }
             JsonValue::Object(map)
         }
 
-        TypeAnnotatedValue::Variant {
-            typ: _,
-            case_name,
-            case_value,
-        } => {
+        TypeAnnotatedValue::Variant(variant) => {
             let mut map = serde_json::Map::new();
             map.insert(
-                case_name.clone(),
-                case_value
+                variant.case_name.clone(),
+                variant
+                    .case_value
                     .as_ref()
-                    .map(|x| get_json_from_typed_value(x))
+                    .map(|x| {
+                        let value = x.clone().deref().type_annotated_value.clone().unwrap();
+                        get_json_from_typed_value(&value)
+                    })
                     .unwrap_or(JsonValue::Null),
             );
             JsonValue::Object(map)
         }
 
-        TypeAnnotatedValue::Result {
-            ok: _,
-            error: _,
-            value,
-        } => {
+        TypeAnnotatedValue::Result(result0) => {
             let mut map = serde_json::Map::new();
-            match value {
-                Ok(ok_value) => {
+
+            let result_value = result0.result_value.clone().unwrap();
+
+            match result_value {
+                ResultValue::OkValue(value) => {
                     map.insert(
                         "ok".to_string(),
-                        ok_value
-                            .as_ref()
-                            .map(|x| get_json_from_typed_value(x))
-                            .unwrap_or(JsonValue::Null),
+                        value
+                            .type_annotated_value
+                            .map_or(JsonValue::Null, |v| get_json_from_typed_value(&v)),
                     );
                 }
-                Err(err_value) => {
+                ResultValue::ErrorValue(value) => {
                     map.insert(
                         "err".to_string(),
-                        err_value
-                            .as_ref()
-                            .map(|x| get_json_from_typed_value(x))
-                            .unwrap_or(JsonValue::Null),
+                        value
+                            .type_annotated_value
+                            .map_or(JsonValue::Null, |v| get_json_from_typed_value(&v)),
                     );
                 }
             }
+
             JsonValue::Object(map)
         }
 
-        TypeAnnotatedValue::Handle {
-            id: _,
-            resource_mode: _,
+        TypeAnnotatedValue::Handle(TypedHandle {
+            typ: _,
             uri,
             resource_id,
-        } => JsonValue::String(format!("{}/{}", uri.value, resource_id)),
+        }) => JsonValue::String(format!("{}/{}", uri, resource_id)),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::json::{get_json_from_typed_value, get_typed_value_from_json};
-    use crate::{TypeAnnotatedValue, Value};
+    use crate::{type_annotated_value, Value};
     use golem_wasm_ast::analysis::AnalysedType;
     use proptest::prelude::*;
     use serde_json::{Number, Value as JsonValue};
@@ -789,7 +937,7 @@ mod tests {
         val: Value,
         expected_type: &AnalysedType,
     ) -> Result<JsonValue, Vec<String>> {
-        TypeAnnotatedValue::from_value(&val, expected_type)
+        type_annotated_value::create(&val, expected_type)
             .map(|result| get_json_from_typed_value(&result))
     }
 

--- a/wasm-rpc/src/lib.rs
+++ b/wasm-rpc/src/lib.rs
@@ -115,6 +115,9 @@ impl wasmtime_wasi::Subscribe for FutureInvokeResultEntry {
 #[cfg(feature = "typeinfo")]
 pub use type_annotated_value::*;
 
+#[cfg(feature = "text")]
+pub use text::{type_annotated_value_from_str, type_annotated_value_to_string};
+
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for Uri {
     fn arbitrary(u: &mut arbitrary::Unstructured) -> arbitrary::Result<Self> {

--- a/wasm-rpc/src/protobuf.rs
+++ b/wasm-rpc/src/protobuf.rs
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::Value;
-use golem_wasm_ast::analysis::AnalysedFunctionParameter;
+use crate::protobuf::typed_result::ResultValue;
+use crate::{Uri, Value};
+use golem_wasm_ast::analysis::{
+    AnalysedFunctionParameter, AnalysedResourceId, AnalysedResourceMode, AnalysedType,
+};
+use std::ops::Deref;
 include!(concat!(env!("OUT_DIR"), "/wasm.rpc.rs"));
 
 // Conversion from WIT WitValue to Protobuf WitValue
@@ -56,10 +60,7 @@ impl From<super::WitNode> for WitNode {
             super::WitNode::ResultValue(type_idx) => WitNode {
                 value: Some(wit_node::Value::Result(WitResultNode {
                     discriminant: if type_idx.is_ok() { 0 } else { 1 },
-                    value: match type_idx {
-                        Ok(index) => index,
-                        Err(index) => index,
-                    },
+                    value: type_idx.unwrap_or_else(|index| index),
                 })),
             },
             super::WitNode::PrimU8(value) => WitNode {
@@ -224,6 +225,505 @@ impl From<super::WitValue> for Val {
     fn from(value: super::WitValue) -> Self {
         let value: Value = value.into();
         value.into()
+    }
+}
+
+impl TryFrom<&type_annotated_value::TypeAnnotatedValue> for Type {
+    type Error = String;
+
+    fn try_from(value: &type_annotated_value::TypeAnnotatedValue) -> Result<Self, Self::Error> {
+        let r#type = match value {
+            type_annotated_value::TypeAnnotatedValue::Bool(_) => {
+                Ok(r#type::Type::Primitive(TypePrimitive {
+                    primitive: PrimitiveType::Bool as i32,
+                }))
+            }
+            type_annotated_value::TypeAnnotatedValue::S8(_) => {
+                Ok(r#type::Type::Primitive(TypePrimitive {
+                    primitive: PrimitiveType::S8 as i32,
+                }))
+            }
+            type_annotated_value::TypeAnnotatedValue::U8(_) => {
+                Ok(r#type::Type::Primitive(TypePrimitive {
+                    primitive: PrimitiveType::U8 as i32,
+                }))
+            }
+            type_annotated_value::TypeAnnotatedValue::S16(_) => {
+                Ok(r#type::Type::Primitive(TypePrimitive {
+                    primitive: PrimitiveType::S16 as i32,
+                }))
+            }
+            type_annotated_value::TypeAnnotatedValue::U16(_) => {
+                Ok(r#type::Type::Primitive(TypePrimitive {
+                    primitive: PrimitiveType::U16 as i32,
+                }))
+            }
+            type_annotated_value::TypeAnnotatedValue::S32(_) => {
+                Ok(r#type::Type::Primitive(TypePrimitive {
+                    primitive: PrimitiveType::S32 as i32,
+                }))
+            }
+            type_annotated_value::TypeAnnotatedValue::U32(_) => {
+                Ok(r#type::Type::Primitive(TypePrimitive {
+                    primitive: PrimitiveType::U32 as i32,
+                }))
+            }
+            type_annotated_value::TypeAnnotatedValue::S64(_) => {
+                Ok(r#type::Type::Primitive(TypePrimitive {
+                    primitive: PrimitiveType::S64 as i32,
+                }))
+            }
+            type_annotated_value::TypeAnnotatedValue::U64(_) => {
+                Ok(r#type::Type::Primitive(TypePrimitive {
+                    primitive: PrimitiveType::U64 as i32,
+                }))
+            }
+            type_annotated_value::TypeAnnotatedValue::F32(_) => {
+                Ok(r#type::Type::Primitive(TypePrimitive {
+                    primitive: PrimitiveType::F32 as i32,
+                }))
+            }
+            type_annotated_value::TypeAnnotatedValue::F64(_) => {
+                Ok(r#type::Type::Primitive(TypePrimitive {
+                    primitive: PrimitiveType::F64 as i32,
+                }))
+            }
+            type_annotated_value::TypeAnnotatedValue::Char(_) => {
+                Ok(r#type::Type::Primitive(TypePrimitive {
+                    primitive: PrimitiveType::Chr as i32,
+                }))
+            }
+            type_annotated_value::TypeAnnotatedValue::Str(_) => {
+                Ok(r#type::Type::Primitive(TypePrimitive {
+                    primitive: PrimitiveType::Str as i32,
+                }))
+            }
+            type_annotated_value::TypeAnnotatedValue::List(TypedList { typ, values: _ }) => {
+                if let Some(typ) = typ.clone() {
+                    Ok(r#type::Type::List(Box::new(TypeList {
+                        elem: Some(Box::new(typ)),
+                    })))
+                } else {
+                    Err("Missing type for List".to_string())
+                }
+            }
+            type_annotated_value::TypeAnnotatedValue::Tuple(TypedTuple { typ, value: _ }) => {
+                Ok(r#type::Type::Tuple(TypeTuple { elems: typ.clone() }))
+            }
+            type_annotated_value::TypeAnnotatedValue::Record(TypedRecord { typ, value: _ }) => {
+                Ok(r#type::Type::Record(TypeRecord {
+                    fields: typ.clone(),
+                }))
+            }
+            type_annotated_value::TypeAnnotatedValue::Flags(TypedFlags { typ, values: _ }) => {
+                Ok(r#type::Type::Flags(TypeFlags { names: typ.clone() }))
+            }
+            type_annotated_value::TypeAnnotatedValue::Enum(TypedEnum { typ, value: _ }) => {
+                Ok(r#type::Type::Enum(TypeEnum { names: typ.clone() }))
+            }
+            type_annotated_value::TypeAnnotatedValue::Option(option) => {
+                let typ = option.typ.clone();
+                Ok(r#type::Type::Option(Box::new(TypeOption {
+                    elem: typ.map(Box::new),
+                })))
+            }
+            type_annotated_value::TypeAnnotatedValue::Result(result0) => {
+                Ok(r#type::Type::Result(Box::new(TypeResult {
+                    ok: result0.ok.clone().map(Box::new),
+                    err: result0.error.clone().map(Box::new),
+                })))
+            }
+            type_annotated_value::TypeAnnotatedValue::Handle(TypedHandle { typ, .. }) => {
+                if let Some(typ) = typ.clone() {
+                    Ok(r#type::Type::Handle(typ))
+                } else {
+                    Err("Missing type for Handle".to_string())
+                }
+            }
+            type_annotated_value::TypeAnnotatedValue::Variant(variant) => {
+                if let Some(typ) = variant.clone().typ {
+                    Ok(r#type::Type::Variant(typ))
+                } else {
+                    Err("Missing type for Variant".to_string())
+                }
+            }
+        };
+
+        r#type.map(|r#type| Type {
+            r#type: Some(r#type),
+        })
+    }
+}
+
+impl TryFrom<&type_annotated_value::TypeAnnotatedValue> for AnalysedType {
+    type Error = String;
+    fn try_from(value: &type_annotated_value::TypeAnnotatedValue) -> Result<Self, Self::Error> {
+        let typ = Type::try_from(value)?;
+        AnalysedType::try_from(&typ)
+    }
+}
+
+impl TryFrom<type_annotated_value::TypeAnnotatedValue> for super::WitValue {
+    type Error = String;
+
+    fn try_from(value: type_annotated_value::TypeAnnotatedValue) -> Result<Self, Self::Error> {
+        let value: Value = value.try_into()?;
+        Ok(super::WitValue::from(value))
+    }
+}
+
+impl TryFrom<&Type> for AnalysedType {
+    type Error = String;
+
+    fn try_from(typ: &Type) -> Result<Self, Self::Error> {
+        match &typ.r#type {
+            Some(r#type::Type::Primitive(primitive)) => {
+                match PrimitiveType::try_from(primitive.primitive) {
+                    Ok(PrimitiveType::Bool) => Ok(AnalysedType::Bool),
+                    Ok(PrimitiveType::S8) => Ok(AnalysedType::S8),
+                    Ok(PrimitiveType::U8) => Ok(AnalysedType::U8),
+                    Ok(PrimitiveType::S16) => Ok(AnalysedType::S16),
+                    Ok(PrimitiveType::U16) => Ok(AnalysedType::U16),
+                    Ok(PrimitiveType::S32) => Ok(AnalysedType::S32),
+                    Ok(PrimitiveType::U32) => Ok(AnalysedType::U32),
+                    Ok(PrimitiveType::S64) => Ok(AnalysedType::S64),
+                    Ok(PrimitiveType::U64) => Ok(AnalysedType::U64),
+                    Ok(PrimitiveType::F32) => Ok(AnalysedType::F32),
+                    Ok(PrimitiveType::F64) => Ok(AnalysedType::F64),
+                    Ok(PrimitiveType::Chr) => Ok(AnalysedType::Chr),
+                    Ok(PrimitiveType::Str) => Ok(AnalysedType::Str),
+                    Err(_) => Err("Unknown primitive type".to_string()),
+                }
+            }
+            Some(r#type::Type::List(inner)) => {
+                let elem_type = inner
+                    .elem
+                    .as_ref()
+                    .ok_or_else(|| "List element type is None".to_string())?;
+                let analysed_type = AnalysedType::try_from(elem_type.as_ref())?;
+                Ok(AnalysedType::List(Box::new(analysed_type)))
+            }
+            Some(r#type::Type::Tuple(inner)) => {
+                let elems = inner
+                    .elems
+                    .iter()
+                    .map(AnalysedType::try_from)
+                    .collect::<Result<Vec<_>, String>>()?;
+                Ok(AnalysedType::Tuple(elems))
+            }
+            Some(r#type::Type::Record(inner)) => {
+                let fields = inner
+                    .fields
+                    .iter()
+                    .map(|field| {
+                        let field_type = field
+                            .typ
+                            .as_ref()
+                            .ok_or_else(|| format!("Record field {} type is None", field.name))?;
+                        let analysed_type = AnalysedType::try_from(field_type)?;
+                        Ok((field.name.clone(), analysed_type))
+                    })
+                    .collect::<Result<Vec<_>, String>>()?;
+                Ok(AnalysedType::Record(fields))
+            }
+            Some(r#type::Type::Flags(inner)) => Ok(AnalysedType::Flags(inner.names.clone())),
+            Some(r#type::Type::Enum(inner)) => Ok(AnalysedType::Enum(inner.names.clone())),
+            Some(r#type::Type::Option(inner)) => {
+                let elem_type = inner
+                    .elem
+                    .as_ref()
+                    .ok_or_else(|| "Option element type is None".to_string())?;
+                let analysed_type = AnalysedType::try_from(elem_type.as_ref())?;
+                Ok(AnalysedType::Option(Box::new(analysed_type)))
+            }
+            Some(r#type::Type::Result(inner)) => {
+                let ok_type = inner
+                    .ok
+                    .as_ref()
+                    .map(|tpe| AnalysedType::try_from(tpe.as_ref()))
+                    .transpose()?;
+                let err_type = inner
+                    .err
+                    .as_ref()
+                    .map(|tpe| AnalysedType::try_from(tpe.as_ref()))
+                    .transpose()?;
+                Ok(AnalysedType::Result {
+                    ok: ok_type.map(Box::new),
+                    error: err_type.map(Box::new),
+                })
+            }
+            Some(r#type::Type::Variant(inner)) => {
+                let cases = inner
+                    .cases
+                    .iter()
+                    .map(|case| {
+                        let case_type =
+                            case.typ.as_ref().map(AnalysedType::try_from).transpose()?;
+                        Ok((case.name.clone(), case_type))
+                    })
+                    .collect::<Result<Vec<_>, String>>()?;
+                Ok(AnalysedType::Variant(cases))
+            }
+            Some(r#type::Type::Handle(inner)) => {
+                let resource_mode = match inner.mode {
+                    0 => Ok(AnalysedResourceMode::Owned),
+                    1 => Ok(AnalysedResourceMode::Borrowed),
+                    _ => Err("Invalid resource mode".to_string()),
+                }?;
+                Ok(AnalysedType::Resource {
+                    id: AnalysedResourceId {
+                        value: inner.resource_id,
+                    },
+                    resource_mode,
+                })
+            }
+            None => Err("Type is None".to_string()),
+        }
+    }
+}
+
+impl From<&AnalysedType> for Type {
+    fn from(value: &AnalysedType) -> Type {
+        let r#type = match value {
+            AnalysedType::Bool => Some(r#type::Type::Primitive(TypePrimitive {
+                primitive: PrimitiveType::Bool as i32,
+            })),
+            AnalysedType::S8 => Some(r#type::Type::Primitive(TypePrimitive {
+                primitive: PrimitiveType::S8 as i32,
+            })),
+            AnalysedType::U8 => Some(r#type::Type::Primitive(TypePrimitive {
+                primitive: PrimitiveType::U8 as i32,
+            })),
+            AnalysedType::S16 => Some(r#type::Type::Primitive(TypePrimitive {
+                primitive: PrimitiveType::S16 as i32,
+            })),
+            AnalysedType::U16 => Some(r#type::Type::Primitive(TypePrimitive {
+                primitive: PrimitiveType::U16 as i32,
+            })),
+            AnalysedType::S32 => Some(r#type::Type::Primitive(TypePrimitive {
+                primitive: PrimitiveType::S32 as i32,
+            })),
+            AnalysedType::U32 => Some(r#type::Type::Primitive(TypePrimitive {
+                primitive: PrimitiveType::U32 as i32,
+            })),
+            AnalysedType::S64 => Some(r#type::Type::Primitive(TypePrimitive {
+                primitive: PrimitiveType::S64 as i32,
+            })),
+            AnalysedType::U64 => Some(r#type::Type::Primitive(TypePrimitive {
+                primitive: PrimitiveType::U64 as i32,
+            })),
+            AnalysedType::F32 => Some(r#type::Type::Primitive(TypePrimitive {
+                primitive: PrimitiveType::F32 as i32,
+            })),
+            AnalysedType::F64 => Some(r#type::Type::Primitive(TypePrimitive {
+                primitive: PrimitiveType::F64 as i32,
+            })),
+            AnalysedType::Chr => Some(r#type::Type::Primitive(TypePrimitive {
+                primitive: PrimitiveType::Chr as i32,
+            })),
+            AnalysedType::Str => Some(r#type::Type::Primitive(TypePrimitive {
+                primitive: PrimitiveType::Str as i32,
+            })),
+            AnalysedType::List(inner) => Some(r#type::Type::List(Box::new(TypeList {
+                elem: Some(Box::new(Type::from(inner.deref()))),
+            }))),
+            AnalysedType::Tuple(elems) => Some(r#type::Type::Tuple(TypeTuple {
+                elems: elems
+                    .iter()
+                    .map(|analysed_type| analysed_type.into())
+                    .collect(),
+            })),
+            AnalysedType::Record(fields) => Some(r#type::Type::Record(TypeRecord {
+                fields: fields
+                    .iter()
+                    .map(|(name, analysed_type)| NameTypePair {
+                        name: name.clone(),
+                        typ: Some(analysed_type.into()),
+                    })
+                    .collect(),
+            })),
+            AnalysedType::Flags(names) => Some(r#type::Type::Flags(TypeFlags {
+                names: names.clone(),
+            })),
+            AnalysedType::Enum(names) => Some(r#type::Type::Enum(TypeEnum {
+                names: names.clone(),
+            })),
+            AnalysedType::Option(inner) => Some(r#type::Type::Option(Box::new(TypeOption {
+                elem: Some(Box::new(Type::from(inner.deref()))),
+            }))),
+            AnalysedType::Result { ok, error } => {
+                Some(r#type::Type::Result(Box::new(TypeResult {
+                    ok: ok
+                        .clone()
+                        .map(|ok_type| Box::new(Type::from(ok_type.as_ref()))),
+                    err: error
+                        .clone()
+                        .map(|err_type| Box::new(Type::from(err_type.as_ref()))),
+                })))
+            }
+            AnalysedType::Variant(cases) => Some(r#type::Type::Variant(TypeVariant {
+                cases: cases
+                    .iter()
+                    .map(|(name, typ)| NameOptionTypePair {
+                        name: name.clone(),
+                        typ: typ.as_ref().map(|analysed_type| analysed_type.into()),
+                    })
+                    .collect(),
+            })),
+            AnalysedType::Resource { id, resource_mode } => {
+                Some(r#type::Type::Handle(TypeHandle {
+                    resource_id: id.value,
+                    mode: match resource_mode {
+                        AnalysedResourceMode::Owned => 0,
+                        AnalysedResourceMode::Borrowed => 1,
+                    },
+                }))
+            }
+        };
+
+        Type { r#type }
+    }
+}
+
+impl TryFrom<type_annotated_value::TypeAnnotatedValue> for Value {
+    type Error = String;
+
+    fn try_from(value: type_annotated_value::TypeAnnotatedValue) -> Result<Self, Self::Error> {
+        match value {
+            type_annotated_value::TypeAnnotatedValue::Bool(value) => Ok(Value::Bool(value)),
+            type_annotated_value::TypeAnnotatedValue::S8(value) => Ok(Value::S8(value as i8)),
+            type_annotated_value::TypeAnnotatedValue::U8(value) => Ok(Value::U8(value as u8)),
+            type_annotated_value::TypeAnnotatedValue::S16(value) => Ok(Value::S16(value as i16)),
+            type_annotated_value::TypeAnnotatedValue::U16(value) => Ok(Value::U16(value as u16)),
+            type_annotated_value::TypeAnnotatedValue::S32(value) => Ok(Value::S32(value)),
+            type_annotated_value::TypeAnnotatedValue::U32(value) => Ok(Value::U32(value)),
+            type_annotated_value::TypeAnnotatedValue::S64(value) => Ok(Value::S64(value)),
+            type_annotated_value::TypeAnnotatedValue::U64(value) => Ok(Value::U64(value)),
+            type_annotated_value::TypeAnnotatedValue::F32(value) => Ok(Value::F32(value)),
+            type_annotated_value::TypeAnnotatedValue::F64(value) => Ok(Value::F64(value)),
+            type_annotated_value::TypeAnnotatedValue::Char(value) => char::from_u32(value as u32)
+                .map(Value::Char)
+                .ok_or_else(|| "Invalid char value".to_string()),
+            type_annotated_value::TypeAnnotatedValue::Str(value) => Ok(Value::String(value)),
+            type_annotated_value::TypeAnnotatedValue::List(TypedList { typ: _, values }) => {
+                let mut list_values = Vec::new();
+                for value in values {
+                    let type_annotated_value = value
+                        .clone()
+                        .type_annotated_value
+                        .ok_or_else(|| "Missing type_annotated_value in List".to_string())?;
+                    list_values.push(type_annotated_value.try_into()?);
+                }
+                Ok(Value::List(list_values))
+            }
+            type_annotated_value::TypeAnnotatedValue::Tuple(TypedTuple { typ: _, value }) => {
+                let mut tuple_values = Vec::new();
+                for value in value {
+                    let type_annotated_value = value
+                        .type_annotated_value
+                        .ok_or_else(|| "Missing type_annotated_value in Tuple".to_string())?;
+                    tuple_values.push(type_annotated_value.try_into()?);
+                }
+                Ok(Value::Tuple(tuple_values))
+            }
+            type_annotated_value::TypeAnnotatedValue::Record(TypedRecord { typ: _, value }) => {
+                let mut record_values = Vec::new();
+                for name_value in value {
+                    let type_annotated_value = name_value
+                        .value
+                        .ok_or_else(|| "Missing value in Record".to_string())?
+                        .type_annotated_value
+                        .ok_or_else(|| "Missing type_annotated_value in Record".to_string())?;
+                    record_values.push(type_annotated_value.try_into()?);
+                }
+                Ok(Value::Record(record_values))
+            }
+            type_annotated_value::TypeAnnotatedValue::Flags(TypedFlags { typ, values }) => {
+                let mut bools = Vec::new();
+                for expected_flag in typ {
+                    bools.push(values.contains(&expected_flag));
+                }
+                Ok(Value::Flags(bools))
+            }
+            type_annotated_value::TypeAnnotatedValue::Enum(TypedEnum { typ, value }) => typ
+                .iter()
+                .position(|expected_enum| expected_enum == &value)
+                .map(|index| Value::Enum(index as u32))
+                .ok_or_else(|| "Enum value not found in the list of expected enums".to_string()),
+            type_annotated_value::TypeAnnotatedValue::Option(option) => match option.value {
+                Some(value) => {
+                    let type_annotated_value = value
+                        .type_annotated_value
+                        .ok_or_else(|| "Missing type_annotated_value in Option".to_string())?;
+                    let value = type_annotated_value.try_into()?;
+                    Ok(Value::Option(Some(Box::new(value))))
+                }
+                None => Ok(Value::Option(None)),
+            },
+            type_annotated_value::TypeAnnotatedValue::Result(result) => {
+                let value = result
+                    .result_value
+                    .ok_or_else(|| "Missing value in Result".to_string())?;
+
+                match value {
+                    ResultValue::OkValue(ok_value) => {
+                        let type_annotated_value =
+                            ok_value.type_annotated_value.ok_or_else(|| {
+                                "Missing type_annotated_value in Result Ok".to_string()
+                            })?;
+                        let value = type_annotated_value.try_into()?;
+                        Ok(Value::Result(Ok(Some(Box::new(value)))))
+                    }
+
+                    ResultValue::ErrorValue(err_value) => {
+                        let type_annotated_value =
+                            err_value.type_annotated_value.ok_or_else(|| {
+                                "Missing type_annotated_value in Result Err".to_string()
+                            })?;
+                        let value = type_annotated_value.try_into()?;
+                        Ok(Value::Result(Err(Some(Box::new(value)))))
+                    }
+                }
+            }
+            type_annotated_value::TypeAnnotatedValue::Handle(handle) => Ok(Value::Handle {
+                uri: Uri { value: handle.uri },
+                resource_id: handle.resource_id,
+            }),
+            type_annotated_value::TypeAnnotatedValue::Variant(variant) => {
+                let case_value = variant.case_value;
+                let case_name = variant.case_name;
+                let typ = variant
+                    .typ
+                    .ok_or_else(|| "Missing typ in Variant".to_string())?
+                    .cases
+                    .iter()
+                    .map(|nt| (nt.name.clone(), nt.typ.clone()))
+                    .collect::<Vec<_>>();
+
+                let case_idx = typ
+                    .iter()
+                    .position(|(name, _)| name == &case_name)
+                    .ok_or_else(|| "Case name not found in Variant".to_string())?
+                    as u32;
+
+                match case_value {
+                    Some(value) => {
+                        let type_annotated_value = value
+                            .type_annotated_value
+                            .ok_or_else(|| "Missing type_annotated_value in Variant".to_string())?;
+                        let result = type_annotated_value.try_into()?;
+                        Ok(Value::Variant {
+                            case_idx,
+                            case_value: Some(Box::new(result)),
+                        })
+                    }
+                    None => Ok(Value::Variant {
+                        case_idx,
+                        case_value: None,
+                    }),
+                }
+            }
+        }
     }
 }
 

--- a/wasm-rpc/src/protobuf.rs
+++ b/wasm-rpc/src/protobuf.rs
@@ -674,15 +674,12 @@ impl TryFrom<type_annotated_value::TypeAnnotatedValue> for Value {
                                 let value = v.try_into()?;
                                 Ok(Value::Result(Ok(Some(Box::new(value)))))
                             }
-                            None => {
-                                Ok(Value::Result(Ok(None)))
-                            }
+                            None => Ok(Value::Result(Ok(None))),
                         }
                     }
 
                     ResultValue::ErrorValue(err_value) => {
-                        let type_annotated_value =
-                            err_value.type_annotated_value;
+                        let type_annotated_value = err_value.type_annotated_value;
 
                         match type_annotated_value {
                             Some(v) => {
@@ -690,9 +687,7 @@ impl TryFrom<type_annotated_value::TypeAnnotatedValue> for Value {
                                 Ok(Value::Result(Err(Some(Box::new(value)))))
                             }
 
-                            None => {
-                                Ok(Value::Result(Err(None)))
-                            }
+                            None => Ok(Value::Result(Err(None))),
                         }
                     }
                 }

--- a/wasm-rpc/src/protobuf.rs
+++ b/wasm-rpc/src/protobuf.rs
@@ -667,21 +667,33 @@ impl TryFrom<type_annotated_value::TypeAnnotatedValue> for Value {
 
                 match value {
                     ResultValue::OkValue(ok_value) => {
-                        let type_annotated_value =
-                            ok_value.type_annotated_value.ok_or_else(|| {
-                                "Missing type_annotated_value in Result Ok".to_string()
-                            })?;
-                        let value = type_annotated_value.try_into()?;
-                        Ok(Value::Result(Ok(Some(Box::new(value)))))
+                        let type_annotated_value = ok_value.type_annotated_value;
+
+                        match type_annotated_value {
+                            Some(v) => {
+                                let value = v.try_into()?;
+                                Ok(Value::Result(Ok(Some(Box::new(value)))))
+                            }
+                            None => {
+                                Ok(Value::Result(Ok(None)))
+                            }
+                        }
                     }
 
                     ResultValue::ErrorValue(err_value) => {
                         let type_annotated_value =
-                            err_value.type_annotated_value.ok_or_else(|| {
-                                "Missing type_annotated_value in Result Err".to_string()
-                            })?;
-                        let value = type_annotated_value.try_into()?;
-                        Ok(Value::Result(Err(Some(Box::new(value)))))
+                            err_value.type_annotated_value;
+
+                        match type_annotated_value {
+                            Some(v) => {
+                                let value = v.try_into()?;
+                                Ok(Value::Result(Err(Some(Box::new(value)))))
+                            }
+
+                            None => {
+                                Ok(Value::Result(Err(None)))
+                            }
+                        }
                     }
                 }
             }

--- a/wasm-rpc/src/text.rs
+++ b/wasm-rpc/src/text.rs
@@ -1,66 +1,97 @@
-use crate::TypeAnnotatedValue;
+use crate::protobuf::type_annotated_value::TypeAnnotatedValue;
+use crate::protobuf::typed_result::ResultValue;
+use crate::protobuf::{
+    NameOptionTypePair, NameTypePair, NameValuePair, TypeVariant, TypedEnum, TypedFlags, TypedList,
+    TypedOption, TypedRecord, TypedTuple, TypedVariant,
+};
+use crate::protobuf::{TypeAnnotatedValue as RootTypeAnnotatedValue, TypedResult};
 use golem_wasm_ast::analysis::AnalysedType;
 use std::borrow::Cow;
+use std::ops::Deref;
 use wasm_wave::wasm::{WasmType, WasmTypeKind, WasmValue, WasmValueError};
+use wasm_wave::{from_str, to_string};
 
-impl WasmValue for TypeAnnotatedValue {
+pub fn type_annotated_value_from_str(
+    analysed_type: &AnalysedType,
+    input: &str,
+) -> Result<TypeAnnotatedValue, String> {
+    let parsed_typed_value: TypeAnnotatedValuePrintable =
+        from_str(analysed_type, input).map_err(|err| err.to_string())?;
+
+    Ok(parsed_typed_value.0)
+}
+
+pub fn type_annotated_value_to_string(value: &TypeAnnotatedValue) -> Result<String, String> {
+    let printable_typed_value: TypeAnnotatedValuePrintable =
+        TypeAnnotatedValuePrintable(value.clone());
+
+    let typed_value_str = to_string(&printable_typed_value).map_err(|err| err.to_string())?;
+
+    Ok(typed_value_str)
+}
+
+#[derive(Debug, Clone)]
+pub struct TypeAnnotatedValuePrintable(pub TypeAnnotatedValue);
+
+impl WasmValue for TypeAnnotatedValuePrintable {
     type Type = AnalysedType;
 
     fn kind(&self) -> WasmTypeKind {
-        let analysed_type = AnalysedType::from(self);
+        let analysed_type = AnalysedType::try_from(&self.0)
+            .expect("Failed to retrieve AnalysedType from TypeAnnotatedValue");
         analysed_type.kind()
     }
 
     fn make_bool(val: bool) -> Self {
-        TypeAnnotatedValue::Bool(val)
+        TypeAnnotatedValuePrintable(TypeAnnotatedValue::Bool(val))
     }
 
     fn make_s8(val: i8) -> Self {
-        TypeAnnotatedValue::S8(val)
+        TypeAnnotatedValuePrintable(TypeAnnotatedValue::S8(val as i32))
     }
 
     fn make_s16(val: i16) -> Self {
-        TypeAnnotatedValue::S16(val)
+        TypeAnnotatedValuePrintable(TypeAnnotatedValue::S16(val as i32))
     }
 
     fn make_s32(val: i32) -> Self {
-        TypeAnnotatedValue::S32(val)
+        TypeAnnotatedValuePrintable(TypeAnnotatedValue::S32(val))
     }
 
     fn make_s64(val: i64) -> Self {
-        TypeAnnotatedValue::S64(val)
+        TypeAnnotatedValuePrintable(TypeAnnotatedValue::S64(val))
     }
 
     fn make_u8(val: u8) -> Self {
-        TypeAnnotatedValue::U8(val)
+        TypeAnnotatedValuePrintable(TypeAnnotatedValue::U8(val as u32))
     }
 
     fn make_u16(val: u16) -> Self {
-        TypeAnnotatedValue::U16(val)
+        TypeAnnotatedValuePrintable(TypeAnnotatedValue::U16(val as u32))
     }
 
     fn make_u32(val: u32) -> Self {
-        TypeAnnotatedValue::U32(val)
+        TypeAnnotatedValuePrintable(TypeAnnotatedValue::U32(val))
     }
 
     fn make_u64(val: u64) -> Self {
-        TypeAnnotatedValue::U64(val)
+        TypeAnnotatedValuePrintable(TypeAnnotatedValue::U64(val))
     }
 
     fn make_float32(val: f32) -> Self {
-        TypeAnnotatedValue::F32(val)
+        TypeAnnotatedValuePrintable(TypeAnnotatedValue::F32(val))
     }
 
     fn make_float64(val: f64) -> Self {
-        TypeAnnotatedValue::F64(val)
+        TypeAnnotatedValuePrintable(TypeAnnotatedValue::F64(val))
     }
 
     fn make_char(val: char) -> Self {
-        TypeAnnotatedValue::Chr(val)
+        TypeAnnotatedValuePrintable(TypeAnnotatedValue::Char(val as i32))
     }
 
     fn make_string(val: Cow<str>) -> Self {
-        TypeAnnotatedValue::Str(val.to_string())
+        TypeAnnotatedValuePrintable(TypeAnnotatedValue::Str(val.to_string()))
     }
 
     fn make_list(
@@ -68,10 +99,17 @@ impl WasmValue for TypeAnnotatedValue {
         vals: impl IntoIterator<Item = Self>,
     ) -> Result<Self, WasmValueError> {
         if let AnalysedType::List(typ) = ty {
-            Ok(TypeAnnotatedValue::List {
-                values: vals.into_iter().collect(),
-                typ: *typ.clone(),
-            })
+            let list = TypedList {
+                values: vals
+                    .into_iter()
+                    .map(|v| RootTypeAnnotatedValue {
+                        type_annotated_value: Some(v.0),
+                    })
+                    .collect(),
+                typ: Some(typ.deref().into()),
+            };
+
+            Ok(TypeAnnotatedValuePrintable(TypeAnnotatedValue::List(list)))
         } else {
             Err(WasmValueError::WrongTypeKind {
                 kind: ty.kind(),
@@ -85,13 +123,27 @@ impl WasmValue for TypeAnnotatedValue {
         fields: impl IntoIterator<Item = (&'a str, Self)>,
     ) -> Result<Self, WasmValueError> {
         if let AnalysedType::Record(types) = ty {
-            Ok(TypeAnnotatedValue::Record {
+            let record = TypedRecord {
                 value: fields
                     .into_iter()
-                    .map(|(name, value)| (name.to_string(), value))
+                    .map(|(name, value)| NameValuePair {
+                        name: name.to_string(),
+                        value: Some(RootTypeAnnotatedValue {
+                            type_annotated_value: Some(value.0),
+                        }),
+                    })
                     .collect(),
-                typ: types.clone(),
-            })
+                typ: types
+                    .iter()
+                    .map(|(name, typ)| NameTypePair {
+                        name: name.clone(),
+                        typ: Some(typ.into()),
+                    })
+                    .collect(),
+            };
+            Ok(TypeAnnotatedValuePrintable(TypeAnnotatedValue::Record(
+                record,
+            )))
         } else {
             Err(WasmValueError::WrongTypeKind {
                 kind: ty.kind(),
@@ -105,10 +157,18 @@ impl WasmValue for TypeAnnotatedValue {
         vals: impl IntoIterator<Item = Self>,
     ) -> Result<Self, WasmValueError> {
         if let AnalysedType::Tuple(types) = ty {
-            Ok(TypeAnnotatedValue::Tuple {
-                value: vals.into_iter().collect(),
-                typ: types.clone(),
-            })
+            let tuple = TypedTuple {
+                value: vals
+                    .into_iter()
+                    .map(|v| RootTypeAnnotatedValue {
+                        type_annotated_value: Some(v.0),
+                    })
+                    .collect(),
+                typ: types.iter().map(|t| t.into()).collect(),
+            };
+            Ok(TypeAnnotatedValuePrintable(TypeAnnotatedValue::Tuple(
+                tuple,
+            )))
         } else {
             Err(WasmValueError::WrongTypeKind {
                 kind: ty.kind(),
@@ -134,11 +194,26 @@ impl WasmValue for TypeAnnotatedValue {
                     },
                 );
             if case_type.is_some() {
-                Ok(TypeAnnotatedValue::Variant {
-                    typ: cases.clone(),
+                let variant = TypedVariant {
+                    typ: Some(TypeVariant {
+                        cases: cases
+                            .iter()
+                            .map(|(name, case_type)| NameOptionTypePair {
+                                name: name.clone(),
+                                typ: case_type.as_ref().map(|v| v.into()),
+                            })
+                            .collect(),
+                    }),
                     case_name: case.to_string(),
-                    case_value: val.map(Box::new),
-                })
+                    case_value: val.map(|v| {
+                        Box::new(RootTypeAnnotatedValue {
+                            type_annotated_value: Some(v.0),
+                        })
+                    }),
+                };
+                Ok(TypeAnnotatedValuePrintable(TypeAnnotatedValue::Variant(
+                    Box::new(variant),
+                )))
             } else {
                 Err(WasmValueError::UnknownCase(case.to_string()))
             }
@@ -153,10 +228,13 @@ impl WasmValue for TypeAnnotatedValue {
     fn make_enum(ty: &Self::Type, case: &str) -> Result<Self, WasmValueError> {
         if let AnalysedType::Enum(cases) = ty {
             if cases.contains(&case.to_string()) {
-                Ok(TypeAnnotatedValue::Enum {
-                    typ: cases.clone(),
+                let enum_value = TypedEnum {
+                    typ: cases.to_vec(),
                     value: case.to_string(),
-                })
+                };
+                Ok(TypeAnnotatedValuePrintable(TypeAnnotatedValue::Enum(
+                    enum_value,
+                )))
             } else {
                 Err(WasmValueError::UnknownCase(case.to_string()))
             }
@@ -169,10 +247,18 @@ impl WasmValue for TypeAnnotatedValue {
     }
 
     fn make_option(ty: &Self::Type, val: Option<Self>) -> Result<Self, WasmValueError> {
-        Ok(TypeAnnotatedValue::Option {
-            typ: ty.clone(),
-            value: val.map(Box::new),
-        })
+        let option = TypedOption {
+            typ: Some(ty.into()),
+            value: val.map(|v| {
+                Box::new(RootTypeAnnotatedValue {
+                    type_annotated_value: Some(v.0),
+                })
+            }),
+        };
+
+        Ok(TypeAnnotatedValuePrintable(TypeAnnotatedValue::Option(
+            Box::new(option),
+        )))
     }
 
     fn make_result(
@@ -180,16 +266,25 @@ impl WasmValue for TypeAnnotatedValue {
         val: Result<Option<Self>, Option<Self>>,
     ) -> Result<Self, WasmValueError> {
         if let AnalysedType::Result { ok, error } = ty {
-            Ok(TypeAnnotatedValue::Result {
-                value: match val {
-                    Ok(Some(v)) => Ok(Some(Box::new(v))),
-                    Ok(None) => Ok(None),
-                    Err(Some(v)) => Err(Some(Box::new(v))),
-                    Err(None) => Err(None),
+            let result0 = TypedResult {
+                ok: ok.clone().map(|v| v.deref().into()),
+                error: error.clone().map(|v| v.deref().into()),
+                result_value: match val {
+                    Ok(Some(v)) => Some(ResultValue::OkValue(Box::new(RootTypeAnnotatedValue {
+                        type_annotated_value: Some(v.0),
+                    }))),
+                    Ok(None) => None,
+                    Err(Some(v)) => {
+                        Some(ResultValue::ErrorValue(Box::new(RootTypeAnnotatedValue {
+                            type_annotated_value: Some(v.0),
+                        })))
+                    }
+                    Err(None) => None,
                 },
-                ok: ok.clone(),
-                error: error.clone(),
-            })
+            };
+            Ok(TypeAnnotatedValuePrintable(TypeAnnotatedValue::Result(
+                Box::new(result0),
+            )))
         } else {
             Err(WasmValueError::WrongTypeKind {
                 kind: ty.kind(),
@@ -212,10 +307,14 @@ impl WasmValue for TypeAnnotatedValue {
                 .collect();
 
             if invalid_names.is_empty() {
-                Ok(TypeAnnotatedValue::Flags {
-                    typ: all_names.clone(),
-                    values: names,
-                })
+                let flags = TypedFlags {
+                    typ: all_names.to_vec(),
+                    values: names.to_vec(),
+                };
+
+                Ok(TypeAnnotatedValuePrintable(TypeAnnotatedValue::Flags(
+                    flags,
+                )))
             } else {
                 Err(WasmValueError::UnknownCase(invalid_names.join(", ")))
             }
@@ -228,134 +327,148 @@ impl WasmValue for TypeAnnotatedValue {
     }
 
     fn unwrap_bool(&self) -> bool {
-        match self {
-            TypeAnnotatedValue::Bool(value) => *value,
+        match self.0 {
+            TypeAnnotatedValue::Bool(value) => value,
             _ => panic!("Expected bool, found {:?}", self),
         }
     }
 
     fn unwrap_s8(&self) -> i8 {
-        match self {
-            TypeAnnotatedValue::S8(value) => *value,
+        match self.0 {
+            TypeAnnotatedValue::S8(value) => value as i8,
             _ => panic!("Expected s8, found {:?}", self),
         }
     }
 
     fn unwrap_s16(&self) -> i16 {
-        match self {
-            TypeAnnotatedValue::S16(value) => *value,
+        match self.0 {
+            TypeAnnotatedValue::S16(value) => value as i16,
             _ => panic!("Expected s16, found {:?}", self),
         }
     }
 
     fn unwrap_s32(&self) -> i32 {
-        match self {
-            TypeAnnotatedValue::S32(value) => *value,
+        match self.0 {
+            TypeAnnotatedValue::S32(value) => value,
             _ => panic!("Expected s32, found {:?}", self),
         }
     }
 
     fn unwrap_s64(&self) -> i64 {
-        match self {
-            TypeAnnotatedValue::S64(value) => *value,
+        match self.0 {
+            TypeAnnotatedValue::S64(value) => value,
             _ => panic!("Expected s64, found {:?}", self),
         }
     }
 
     fn unwrap_u8(&self) -> u8 {
-        match self {
-            TypeAnnotatedValue::U8(value) => *value,
+        match self.0 {
+            TypeAnnotatedValue::U8(value) => value as u8,
             _ => panic!("Expected u8, found {:?}", self),
         }
     }
 
     fn unwrap_u16(&self) -> u16 {
-        match self {
-            TypeAnnotatedValue::U16(value) => *value,
+        match self.0 {
+            TypeAnnotatedValue::U16(value) => value as u16,
             _ => panic!("Expected u16, found {:?}", self),
         }
     }
 
     fn unwrap_u32(&self) -> u32 {
-        match self {
-            TypeAnnotatedValue::U32(value) => *value,
+        match self.0 {
+            TypeAnnotatedValue::U32(value) => value,
             _ => panic!("Expected u32, found {:?}", self),
         }
     }
 
     fn unwrap_u64(&self) -> u64 {
-        match self {
-            TypeAnnotatedValue::U64(value) => *value,
+        match self.0 {
+            TypeAnnotatedValue::U64(value) => value,
             _ => panic!("Expected u64, found {:?}", self),
         }
     }
 
     fn unwrap_float32(&self) -> f32 {
-        match self {
-            TypeAnnotatedValue::F32(value) => *value,
+        match self.0 {
+            TypeAnnotatedValue::F32(value) => value,
             _ => panic!("Expected f32, found {:?}", self),
         }
     }
 
     fn unwrap_float64(&self) -> f64 {
-        match self {
-            TypeAnnotatedValue::F64(value) => *value,
+        match self.0 {
+            TypeAnnotatedValue::F64(value) => value,
             _ => panic!("Expected f64, found {:?}", self),
         }
     }
 
     fn unwrap_char(&self) -> char {
-        match self {
-            TypeAnnotatedValue::Chr(value) => *value,
+        match self.0 {
+            TypeAnnotatedValue::Char(value) => char::from_u32(value as u32).unwrap(),
             _ => panic!("Expected chr, found {:?}", self),
         }
     }
 
     fn unwrap_string(&self) -> Cow<str> {
-        match self {
-            TypeAnnotatedValue::Str(value) => Cow::Borrowed(value),
+        match self.0.clone() {
+            TypeAnnotatedValue::Str(value) => Cow::Owned(value.clone()),
             _ => panic!("Expected string, found {:?}", self),
         }
     }
 
     fn unwrap_list(&self) -> Box<dyn Iterator<Item = Cow<Self>> + '_> {
-        match self {
-            TypeAnnotatedValue::List { typ: _, values } => {
-                Box::new(values.iter().map(Cow::Borrowed))
+        match self.0.clone() {
+            TypeAnnotatedValue::List(TypedList { typ: _, values }) => {
+                Box::new(values.into_iter().map(|v| {
+                    Cow::Owned(TypeAnnotatedValuePrintable(
+                        v.type_annotated_value.as_ref().unwrap().clone(),
+                    ))
+                }))
             }
             _ => panic!("Expected list, found {:?}", self),
         }
     }
 
     fn unwrap_record(&self) -> Box<dyn Iterator<Item = (Cow<str>, Cow<Self>)> + '_> {
-        match self {
-            TypeAnnotatedValue::Record { typ: _, value } => Box::new(
-                value
-                    .iter()
-                    .map(|(name, value)| (Cow::Borrowed(name.as_str()), Cow::Borrowed(value))),
-            ),
+        match self.0.clone() {
+            TypeAnnotatedValue::Record(TypedRecord { typ: _, value }) => {
+                Box::new(value.into_iter().map(|name_value| {
+                    let name = name_value.name.clone();
+                    let type_annotated_value =
+                        name_value.value.unwrap().type_annotated_value.unwrap();
+                    (
+                        Cow::Owned(name),
+                        Cow::Owned(TypeAnnotatedValuePrintable(type_annotated_value)),
+                    )
+                }))
+            }
             _ => panic!("Expected record, found {:?}", self),
         }
     }
 
     fn unwrap_tuple(&self) -> Box<dyn Iterator<Item = Cow<Self>> + '_> {
-        match self {
-            TypeAnnotatedValue::Tuple { typ: _, value } => {
-                Box::new(value.iter().map(Cow::Borrowed))
+        match self.0.clone() {
+            TypeAnnotatedValue::Tuple(TypedTuple { typ: _, value }) => {
+                Box::new(value.into_iter().map(|x| {
+                    if let Some(ref v) = x.type_annotated_value {
+                        Cow::Owned(TypeAnnotatedValuePrintable(v.clone()))
+                    } else {
+                        panic!("Expected value, found None")
+                    }
+                }))
             }
             _ => panic!("Expected tuple, found {:?}", self),
         }
     }
 
     fn unwrap_variant(&self) -> (Cow<str>, Option<Cow<Self>>) {
-        match self {
-            TypeAnnotatedValue::Variant {
-                typ: _,
-                case_name,
-                case_value,
-            } => {
-                let case_name = Cow::Borrowed(case_name.as_str());
-                let case_value = case_value.clone().map(|v| Cow::Owned(*v));
+        match self.0.clone() {
+            TypeAnnotatedValue::Variant(variant) => {
+                let case_name = Cow::Owned(variant.case_name);
+                let case_value = variant.case_value.clone().map(|v| {
+                    Cow::Owned(TypeAnnotatedValuePrintable(v.type_annotated_value.unwrap()))
+                });
                 (case_name, case_value)
             }
             _ => panic!("Expected variant, found {:?}", self),
@@ -363,41 +476,50 @@ impl WasmValue for TypeAnnotatedValue {
     }
 
     fn unwrap_enum(&self) -> Cow<str> {
-        match self {
-            TypeAnnotatedValue::Enum { typ: _, value } => Cow::Borrowed(value.as_str()),
+        match self.0.clone() {
+            TypeAnnotatedValue::Enum(TypedEnum { typ: _, value }) => Cow::Owned(value),
             _ => panic!("Expected enum, found {:?}", self),
         }
     }
 
     fn unwrap_option(&self) -> Option<Cow<Self>> {
-        match self {
-            TypeAnnotatedValue::Option { typ: _, value } => {
-                value.as_ref().map(|v| Cow::Owned(*v.clone()))
-            }
+        match self.0.clone() {
+            TypeAnnotatedValue::Option(option) => option.value.as_ref().and_then(|v| {
+                v.type_annotated_value
+                    .as_ref()
+                    .map(|inner| Cow::Owned(TypeAnnotatedValuePrintable(inner.clone())))
+            }),
             _ => panic!("Expected option, found {:?}", self),
         }
     }
 
     fn unwrap_result(&self) -> Result<Option<Cow<Self>>, Option<Cow<Self>>> {
-        match self {
-            TypeAnnotatedValue::Result {
-                ok: _,
-                error: _,
-                value,
-            } => match value {
-                Ok(Some(v)) => Ok(Some(Cow::Borrowed(v))),
-                Ok(None) => Ok(None),
-                Err(Some(v)) => Err(Some(Cow::Borrowed(v))),
-                Err(None) => Err(None),
+        match self.0.clone() {
+            TypeAnnotatedValue::Result(result0) => match result0.result_value {
+                Some(result) => match result {
+                    ResultValue::OkValue(ok) => match ok.type_annotated_value {
+                        Some(ok_value) => {
+                            Ok(Some(Cow::Owned(TypeAnnotatedValuePrintable(ok_value))))
+                        }
+                        None => panic!("Expected ok, found None"),
+                    },
+                    ResultValue::ErrorValue(error) => match error.type_annotated_value {
+                        Some(error_value) => {
+                            Err(Some(Cow::Owned(TypeAnnotatedValuePrintable(error_value))))
+                        }
+                        None => panic!("Expected error, found None"),
+                    },
+                },
+                None => panic!("Expected ok, found None"),
             },
             _ => panic!("Expected result, found {:?}", self),
         }
     }
 
     fn unwrap_flags(&self) -> Box<dyn Iterator<Item = Cow<str>> + '_> {
-        match self {
-            TypeAnnotatedValue::Flags { typ: _, values } => {
-                Box::new(values.iter().map(|v| Cow::Borrowed(v.as_str())))
+        match self.0.clone() {
+            TypeAnnotatedValue::Flags(TypedFlags { typ: _, values }) => {
+                Box::new(values.into_iter().map(Cow::Owned))
             }
             _ => panic!("Expected flags, found {:?}", self),
         }
@@ -406,18 +528,20 @@ impl WasmValue for TypeAnnotatedValue {
 
 #[cfg(test)]
 mod tests {
-    use crate::{TypeAnnotatedValue, Value};
+    use crate::protobuf::type_annotated_value::TypeAnnotatedValue;
+    use crate::text::type_annotated_value_from_str;
+    use crate::{create, type_annotated_value_to_string, Value};
     use golem_wasm_ast::analysis::AnalysedType;
-    use wasm_wave::{from_str, to_string};
 
     fn round_trip(value: Value, typ: AnalysedType) {
-        let typed_value = TypeAnnotatedValue::from_value(&value, &typ).unwrap();
+        let typed_value = create(&value, &typ).unwrap();
         println!("{:?}", typed_value.clone());
 
-        let s = to_string(&typed_value).unwrap();
+        let s = type_annotated_value_to_string(&typed_value).unwrap();
         let round_trip_value: TypeAnnotatedValue =
-            from_str(&AnalysedType::from(&typed_value), &s).unwrap();
-        let result: Value = round_trip_value.try_into().unwrap();
+            type_annotated_value_from_str(&AnalysedType::try_from(&typed_value).unwrap(), &s)
+                .unwrap();
+        let result: Value = Value::try_from(round_trip_value).unwrap();
         assert_eq!(value, result);
     }
 

--- a/wasm-rpc/src/type_annotated_value.rs
+++ b/wasm-rpc/src/type_annotated_value.rs
@@ -1,512 +1,365 @@
-use std::convert::{TryFrom, TryInto};
+use crate::Value;
 
-use golem_wasm_ast::analysis::{AnalysedResourceId, AnalysedResourceMode, AnalysedType};
+use crate::protobuf::type_annotated_value::TypeAnnotatedValue;
+use crate::protobuf::typed_result::ResultValue;
+use crate::protobuf::{NameValuePair, TypedOption};
+use crate::protobuf::{
+    Type, TypedEnum, TypedFlags, TypedHandle, TypedList, TypedRecord, TypedTuple, TypedVariant,
+};
+use crate::protobuf::{TypeAnnotatedValue as RootTypeAnnotatedValue, TypedResult};
 
-use crate::{Uri, Value, WitValue};
-
-use std::ops::Deref;
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum TypeAnnotatedValue {
-    Bool(bool),
-    S8(i8),
-    U8(u8),
-    S16(i16),
-    U16(u16),
-    S32(i32),
-    U32(u32),
-    S64(i64),
-    U64(u64),
-    F32(f32),
-    F64(f64),
-    Chr(char),
-    Str(String),
-    List {
-        typ: AnalysedType,
-        values: Vec<TypeAnnotatedValue>,
-    },
-    Tuple {
-        typ: Vec<AnalysedType>,
-        value: Vec<TypeAnnotatedValue>,
-    },
-    Record {
-        typ: Vec<(String, AnalysedType)>,
-        value: Vec<(String, TypeAnnotatedValue)>,
-    },
-    Flags {
-        typ: Vec<String>,
-        values: Vec<String>,
-    },
-    Variant {
-        typ: Vec<(String, Option<AnalysedType>)>,
-        case_name: String,
-        case_value: Option<Box<TypeAnnotatedValue>>,
-    },
-    Enum {
-        typ: Vec<String>,
-        value: String,
-    },
-    Option {
-        typ: AnalysedType,
-        value: Option<Box<TypeAnnotatedValue>>,
-    },
-    Result {
-        ok: Option<Box<AnalysedType>>,
-        error: Option<Box<AnalysedType>>,
-        value: Result<Option<Box<TypeAnnotatedValue>>, Option<Box<TypeAnnotatedValue>>>,
-    },
-    Handle {
-        id: AnalysedResourceId,
-        resource_mode: AnalysedResourceMode,
-        uri: Uri,
-        resource_id: u64,
-    },
+pub fn create<T: Into<Type>>(value: &Value, typ: T) -> Result<TypeAnnotatedValue, Vec<String>> {
+    let tpe: Type = typ.into();
+    create_from_type(value, &tpe)
 }
 
-impl TypeAnnotatedValue {
-    pub fn from_value(
-        val: &Value,
-        analysed_type: &AnalysedType,
-    ) -> Result<TypeAnnotatedValue, Vec<String>> {
-        match val {
-            Value::Bool(bool) => Ok(TypeAnnotatedValue::Bool(*bool)),
-            Value::S8(value) => Ok(TypeAnnotatedValue::S8(*value)),
-            Value::U8(value) => Ok(TypeAnnotatedValue::U8(*value)),
-            Value::U32(value) => Ok(TypeAnnotatedValue::U32(*value)),
-            Value::S16(value) => Ok(TypeAnnotatedValue::S16(*value)),
-            Value::U16(value) => Ok(TypeAnnotatedValue::U16(*value)),
-            Value::S32(value) => Ok(TypeAnnotatedValue::S32(*value)),
-            Value::S64(value) => Ok(TypeAnnotatedValue::S64(*value)),
-            Value::U64(value) => Ok(TypeAnnotatedValue::U64(*value)),
-            Value::F32(value) => Ok(TypeAnnotatedValue::F32(*value)),
-            Value::F64(value) => Ok(TypeAnnotatedValue::F64(*value)),
-            Value::Char(value) => Ok(TypeAnnotatedValue::Chr(*value)),
-            Value::String(value) => Ok(TypeAnnotatedValue::Str(value.clone())),
+fn create_from_type(val: &Value, typ: &Type) -> Result<TypeAnnotatedValue, Vec<String>> {
+    match val {
+        Value::Bool(bool) => Ok(TypeAnnotatedValue::Bool(*bool)),
+        Value::S8(value) => Ok(TypeAnnotatedValue::S8(*value as i32)),
+        Value::U8(value) => Ok(TypeAnnotatedValue::U8(*value as u32)),
+        Value::U32(value) => Ok(TypeAnnotatedValue::U32(*value)),
+        Value::S16(value) => Ok(TypeAnnotatedValue::S16(*value as i32)),
+        Value::U16(value) => Ok(TypeAnnotatedValue::U16(*value as u32)),
+        Value::S32(value) => Ok(TypeAnnotatedValue::S32(*value)),
+        Value::S64(value) => Ok(TypeAnnotatedValue::S64(*value)),
+        Value::U64(value) => Ok(TypeAnnotatedValue::U64(*value)),
+        Value::F32(value) => Ok(TypeAnnotatedValue::F32(*value)),
+        Value::F64(value) => Ok(TypeAnnotatedValue::F64(*value)),
+        Value::Char(value) => Ok(TypeAnnotatedValue::Char(*value as i32)),
+        Value::String(value) => Ok(TypeAnnotatedValue::Str(value.clone())),
 
-            Value::Enum(value) => match analysed_type {
-                AnalysedType::Enum(names) => match names.get(*value as usize) {
-                    Some(str) => Ok(TypeAnnotatedValue::Enum {
-                        typ: names.clone(),
-                        value: str.to_string(),
-                    }),
-                    None => Err(vec![format!("Invalid enum {}", value)]),
-                },
-                _ => Err(vec![format!("Unexpected enum {}", value)]),
-            },
+        Value::Enum(value) => match &typ.r#type {
+            Some(crate::protobuf::r#type::Type::Enum(typ_enum)) => {
+                match typ_enum.names.get(*value as usize) {
+                    Some(name) => Ok(TypeAnnotatedValue::Enum(TypedEnum {
+                        typ: typ_enum.names.clone(),
+                        value: name.clone(),
+                    })),
+                    None => Err(vec![format!("Invalid enum value {}", value)]),
+                }
+            }
+            _ => Err(vec![format!(
+                "Unexpected type; expected an Enum type for value {}",
+                value
+            )]),
+        },
 
-            Value::Option(value) => match analysed_type {
-                AnalysedType::Option(elem) => Ok(TypeAnnotatedValue::Option {
-                    typ: *elem.clone(),
-                    value: match value {
-                        Some(value) => Some(Box::new(Self::from_value(value, elem)?)),
-                        None => None,
-                    },
-                }),
-
-                _ => Err(vec!["Unexpected type; expected an Option type.".to_string()]),
-            },
-
-            Value::Tuple(values) => match analysed_type {
-                AnalysedType::Tuple(types) => {
-                    if values.len() != types.len() {
-                        return Err(vec![format!(
-                            "Tuple has unexpected number of elements: {} vs {}",
-                            values.len(),
-                            types.len(),
-                        )]);
-                    }
-
-                    let mut errors = vec![];
-                    let mut results = vec![];
-
-                    for (value, tpe) in values.iter().zip(types.iter()) {
-                        match Self::from_value(value, tpe) {
-                            Ok(result) => results.push(result),
-                            Err(errs) => errors.extend(errs),
-                        }
-                    }
-
-                    if errors.is_empty() {
-                        Ok(TypeAnnotatedValue::Tuple {
-                            typ: types.clone(),
-                            value: results,
-                        })
+        Value::Option(value) => match &typ.r#type {
+            Some(crate::protobuf::r#type::Type::Option(typ_option)) => match value {
+                Some(value) => {
+                    if let Some(inner_type) = &typ_option.elem {
+                        let result = create_from_type(value, inner_type)?;
+                        Ok(TypeAnnotatedValue::Option(Box::new(TypedOption {
+                            typ: Some((**inner_type).clone()),
+                            value: Some(Box::new(RootTypeAnnotatedValue {
+                                type_annotated_value: Some(result),
+                            })),
+                        })))
                     } else {
-                        Err(errors)
+                        Err(vec!["Unexpected inner type for Option.".to_string()])
+                    }
+                }
+                None => Ok(TypeAnnotatedValue::Option(Box::new(TypedOption {
+                    typ: typ_option.elem.as_deref().cloned(),
+                    value: None,
+                }))),
+            },
+            _ => Err(vec!["Unexpected type; expected an Option type.".to_string()]),
+        },
+
+        Value::Tuple(values) => match &typ.r#type {
+            Some(crate::protobuf::r#type::Type::Tuple(typ_tuple)) => {
+                if values.len() != typ_tuple.elems.len() {
+                    return Err(vec![format!(
+                        "Tuple has unexpected number of elements: {} vs {}",
+                        values.len(),
+                        typ_tuple.elems.len(),
+                    )]);
+                }
+
+                let mut errors = vec![];
+                let mut results = vec![];
+
+                for (value, tpe) in values.iter().zip(&typ_tuple.elems) {
+                    match create_from_type(value, tpe) {
+                        Ok(result) => results.push(result),
+                        Err(errs) => errors.extend(errs),
                     }
                 }
 
-                _ => Err(vec!["Unexpected type; expected a tuple type.".to_string()]),
-            },
+                if errors.is_empty() {
+                    Ok(TypeAnnotatedValue::Tuple(TypedTuple {
+                        typ: typ_tuple.elems.clone(),
+                        value: results
+                            .into_iter()
+                            .map(|v| RootTypeAnnotatedValue {
+                                type_annotated_value: Some(v),
+                            })
+                            .collect(),
+                    }))
+                } else {
+                    Err(errors)
+                }
+            }
+            _ => Err(vec!["Unexpected type; expected a Tuple type.".to_string()]),
+        },
 
-            Value::List(values) => match analysed_type {
-                AnalysedType::List(elem) => {
+        Value::List(values) => match &typ.r#type {
+            Some(crate::protobuf::r#type::Type::List(typ_list)) => {
+                if let Some(inner_type) = &typ_list.elem {
                     let mut errors = vec![];
                     let mut results = vec![];
 
                     for value in values {
-                        match Self::from_value(value, elem) {
+                        match create_from_type(value, inner_type) {
                             Ok(value) => results.push(value),
                             Err(errs) => errors.extend(errs),
                         }
                     }
 
                     if errors.is_empty() {
-                        Ok(TypeAnnotatedValue::List {
-                            typ: *elem.clone(),
-                            values: results,
-                        })
+                        Ok(TypeAnnotatedValue::List(TypedList {
+                            typ: Some((**inner_type).clone()),
+                            values: results
+                                .into_iter()
+                                .map(|v| RootTypeAnnotatedValue {
+                                    type_annotated_value: Some(v),
+                                })
+                                .collect(),
+                        }))
                     } else {
                         Err(errors)
                     }
+                } else {
+                    Err(vec!["Unexpected inner type for List.".to_string()])
+                }
+            }
+            _ => Err(vec!["Unexpected type; expected a List type.".to_string()]),
+        },
+
+        Value::Record(values) => match &typ.r#type {
+            Some(crate::protobuf::r#type::Type::Record(typ_record)) => {
+                if values.len() != typ_record.fields.len() {
+                    return Err(vec!["The total number of field values is zero".to_string()]);
                 }
 
-                _ => Err(vec!["Unexpected type; expected a list type.".to_string()]),
-            },
+                let mut errors = vec![];
+                let mut results = vec![];
 
-            Value::Record(values) => match analysed_type {
-                AnalysedType::Record(fields) => {
-                    if values.len() != fields.len() {
-                        return Err(vec!["The total number of field values is zero".to_string()]);
-                    }
-
-                    let mut errors = vec![];
-                    let mut results: Vec<(String, TypeAnnotatedValue)> = vec![];
-
-                    for (value, (field_name, typ)) in values.iter().zip(fields) {
-                        match TypeAnnotatedValue::from_value(value, typ) {
-                            Ok(res) => {
-                                results.push((field_name.clone(), res));
-                            }
+                for (value, field) in values.iter().zip(&typ_record.fields) {
+                    if let Some(field_type) = &field.typ {
+                        match create_from_type(value, field_type) {
+                            Ok(res) => results.push((field.name.clone(), res)),
                             Err(errs) => errors.extend(errs),
                         }
-                    }
-
-                    if errors.is_empty() {
-                        Ok(TypeAnnotatedValue::Record {
-                            typ: fields.clone(),
-                            value: results,
-                        })
                     } else {
-                        Err(errors)
+                        errors.push(format!("Missing type for field {}", field.name));
                     }
                 }
 
-                _ => Err(vec!["Unexpected type; expected a variant type.".to_string()]),
-            },
+                if errors.is_empty() {
+                    Ok(TypeAnnotatedValue::Record(TypedRecord {
+                        typ: typ_record.fields.clone(),
+                        value: results
+                            .into_iter()
+                            .map(|(name, value)| NameValuePair {
+                                name,
+                                value: Some(RootTypeAnnotatedValue {
+                                    type_annotated_value: Some(value),
+                                }),
+                            })
+                            .collect(),
+                    }))
+                } else {
+                    Err(errors)
+                }
+            }
+            _ => Err(vec!["Unexpected type; expected a Record type.".to_string()]),
+        },
 
-            Value::Variant {
-                case_idx,
-                case_value,
-            } => match analysed_type {
-                AnalysedType::Variant(cases) => {
-                    if (*case_idx as usize) < cases.len() {
-                        let (case_name, case_type) = match cases.get(*case_idx as usize) {
-                            Some(tpe) => Ok(tpe),
-                            None => {
-                                Err(vec!["Variant not found in the expected types.".to_string()])
+        Value::Variant {
+            case_idx,
+            case_value,
+        } => match &typ.r#type {
+            Some(crate::protobuf::r#type::Type::Variant(typ_variant)) => {
+                if (*case_idx as usize) < typ_variant.cases.len() {
+                    let cases = typ_variant.cases.clone();
+
+                    let (case_name, case_tpe) = match cases.get(*case_idx as usize) {
+                        Some(tpe) => Ok((tpe.name.clone(), tpe.typ.clone())),
+                        None => Err(vec!["Variant not found in the expected types.".to_string()]),
+                    }?;
+
+                    match case_tpe {
+                        Some(tpe) => match case_value {
+                            Some(case_value) => {
+                                let result = create_from_type(case_value, &tpe)?;
+
+                                Ok(TypeAnnotatedValue::Variant(Box::new(TypedVariant {
+                                    typ: Some(crate::protobuf::TypeVariant { cases }),
+                                    case_name: case_name.clone(),
+                                    case_value: Some(Box::new(RootTypeAnnotatedValue {
+                                        type_annotated_value: Some(result),
+                                    })),
+                                })))
                             }
-                        }?;
+                            None => Err(vec![format!("Missing value for case {case_name}")]),
+                        },
+                        None => Ok(TypeAnnotatedValue::Variant(Box::new(TypedVariant {
+                            typ: Some(crate::protobuf::TypeVariant { cases }),
+                            case_name: case_name.clone(),
+                            case_value: None,
+                        }))),
+                    }
+                } else {
+                    Err(vec![
+                        "Invalid discriminant value for the variant.".to_string()
+                    ])
+                }
+            }
+            _ => Err(vec!["Unexpected type; expected a Variant type.".to_string()]),
+        },
 
-                        match case_type {
-                            Some(tpe) => match case_value {
-                                Some(case_value) => {
-                                    let result = Self::from_value(case_value, tpe)?;
-                                    Ok(TypeAnnotatedValue::Variant {
-                                        typ: cases.clone(),
-                                        case_name: case_name.clone(),
-                                        case_value: Some(Box::new(result)),
-                                    })
-                                }
-                                None => Err(vec![format!("Missing value for case {case_name}")]),
+        Value::Flags(values) => match &typ.r#type {
+            Some(crate::protobuf::r#type::Type::Flags(typ_flags)) => {
+                if values.len() != typ_flags.names.len() {
+                    return Err(vec![format!(
+                        "Unexpected number of flag states: {:?} vs {:?}",
+                        values.len(),
+                        typ_flags.names.len()
+                    )]);
+                }
+
+                let enabled_flags: Vec<String> = values
+                    .iter()
+                    .zip(typ_flags.names.iter())
+                    .filter_map(|(enabled, name)| if *enabled { Some(name.clone()) } else { None })
+                    .collect();
+
+                Ok(TypeAnnotatedValue::Flags(TypedFlags {
+                    typ: typ_flags.names.clone(),
+                    values: enabled_flags,
+                }))
+            }
+            _ => Err(vec!["Unexpected type; expected a Flags type.".to_string()]),
+        },
+
+        Value::Result(value) => match &typ.r#type {
+            Some(crate::protobuf::r#type::Type::Result(typ_result)) => {
+                match (value, &typ_result.ok, &typ_result.err) {
+                    (Ok(Some(value)), Some(ok_type), _) => {
+                        let result = create_from_type(value, ok_type)?;
+
+                        Ok(TypeAnnotatedValue::Result(Box::new(TypedResult {
+                            ok: Some(ok_type.as_ref().clone()),
+                            error: typ_result.err.clone().map(|t| (*t).clone()),
+                            result_value: Some(ResultValue::OkValue(Box::new(
+                                RootTypeAnnotatedValue {
+                                    type_annotated_value: Some(result),
+                                },
+                            ))),
+                        })))
+                    }
+                    (Ok(None), Some(_), _) => {
+                        Err(vec!["Non-unit ok result has no value".to_string()])
+                    }
+
+                    (Ok(None), None, _) => Ok(TypeAnnotatedValue::Result(Box::new(TypedResult {
+                        ok: typ_result.ok.clone().map(|t| (*t).clone()),
+                        error: typ_result.err.clone().map(|t| (*t).clone()),
+                        result_value: Some(ResultValue::OkValue(Box::new(
+                            RootTypeAnnotatedValue {
+                                type_annotated_value: None,
                             },
-                            None => Ok(TypeAnnotatedValue::Variant {
-                                typ: cases.clone(),
-                                case_name: case_name.clone(),
-                                case_value: None,
-                            }),
-                        }
-                    } else {
-                        Err(vec![
-                            "Invalid discriminant value for the variant.".to_string()
-                        ])
+                        ))),
+                    }))),
+
+                    (Ok(Some(_)), None, _) => Err(vec!["Unit ok result has a value".to_string()]),
+
+                    (Err(Some(value)), _, Some(err_type)) => {
+                        let result = create_from_type(value, err_type)?;
+
+                        Ok(TypeAnnotatedValue::Result(Box::new(TypedResult {
+                            ok: typ_result.ok.clone().map(|t| (*t).clone()),
+                            error: typ_result.err.clone().map(|t| (*t).clone()),
+                            result_value: Some(ResultValue::ErrorValue(Box::new(
+                                RootTypeAnnotatedValue {
+                                    type_annotated_value: Some(result),
+                                },
+                            ))),
+                        })))
+                    }
+
+                    (Err(None), _, Some(_)) => {
+                        Err(vec!["Non-unit error result has no value".to_string()])
+                    }
+
+                    (Err(None), _, None) => Ok(TypeAnnotatedValue::Result(Box::new(TypedResult {
+                        ok: typ_result.ok.clone().map(|t| (*t).clone()),
+                        error: typ_result.err.clone().map(|t| (*t).clone()),
+                        result_value: Some(ResultValue::ErrorValue(Box::new(
+                            RootTypeAnnotatedValue {
+                                type_annotated_value: None,
+                            },
+                        ))),
+                    }))),
+
+                    (Err(Some(_)), _, None) => {
+                        Err(vec!["Unit error result has a value".to_string()])
                     }
                 }
+            }
 
-                _ => Err(vec!["Unexpected type; expected a variant type.".to_string()]),
-            },
+            _ => Err(vec!["Unexpected type; expected a Result type.".to_string()]),
+        },
 
-            Value::Flags(values) => match analysed_type {
-                AnalysedType::Flags(names) => {
-                    let mut results = vec![];
-
-                    if values.len() != names.len() {
-                        Err(vec![format!(
-                            "Unexpected number of flag states: {:?} vs {:?}",
-                            values, names
-                        )])
-                    } else {
-                        for (enabled, name) in values.iter().zip(names) {
-                            if *enabled {
-                                results.push(name.clone());
-                            }
-                        }
-
-                        Ok(TypeAnnotatedValue::Flags {
-                            typ: names.clone(),
-                            values: results,
-                        })
-                    }
-                }
-                _ => Err(vec!["Unexpected type; expected a flags type.".to_string()]),
-            },
-
-            Value::Result(value) => match analysed_type {
-                golem_wasm_ast::analysis::AnalysedType::Result { ok, error } => {
-                    match (value, ok, error) {
-                        (Ok(Some(value)), Some(ok_type), _) => {
-                            let result = Self::from_value(value, ok_type)?;
-
-                            Ok(TypeAnnotatedValue::Result {
-                                value: Ok(Some(Box::new(result))),
-                                ok: ok.clone(),
-                                error: error.clone(),
-                            })
-                        }
-
-                        (Ok(None), Some(_), _) => {
-                            Err(vec!["Non-unit ok result has no value".to_string()])
-                        }
-
-                        (Ok(None), None, _) => Ok(TypeAnnotatedValue::Result {
-                            value: Ok(None),
-                            ok: ok.clone(),
-                            error: error.clone(),
-                        }),
-
-                        (Ok(Some(_)), None, _) => {
-                            Err(vec!["Unit ok result has a value".to_string()])
-                        }
-
-                        (Err(Some(value)), _, Some(err_type)) => {
-                            let result = Self::from_value(value, err_type)?;
-
-                            Ok(TypeAnnotatedValue::Result {
-                                value: Err(Some(Box::new(result))),
-                                ok: ok.clone(),
-                                error: error.clone(),
-                            })
-                        }
-
-                        (Err(None), _, Some(_)) => {
-                            Err(vec!["Non-unit error result has no value".to_string()])
-                        }
-
-                        (Err(None), _, None) => Ok(TypeAnnotatedValue::Result {
-                            value: Err(None),
-                            ok: ok.clone(),
-                            error: error.clone(),
-                        }),
-
-                        (Err(Some(_)), _, None) => {
-                            Err(vec!["Unit error result has a value".to_string()])
-                        }
-                    }
-                }
-
-                _ => Err(vec!["Unexpected type; expected a Result type.".to_string()]),
-            },
-            Value::Handle { uri, resource_id } => match analysed_type {
-                AnalysedType::Resource { id, resource_mode } => Ok(TypeAnnotatedValue::Handle {
-                    id: id.clone(),
-                    resource_mode: resource_mode.clone(),
-                    uri: uri.clone(),
+        Value::Handle { uri, resource_id } => match &typ.r#type {
+            Some(crate::protobuf::r#type::Type::Handle(typ_handle)) => {
+                let handle = TypedHandle {
+                    uri: uri.value.clone(),
                     resource_id: *resource_id,
-                }),
-                _ => Err(vec!["Unexpected type; expected a Handle type.".to_string()]),
-            },
-        }
+                    typ: Some(typ_handle.clone()),
+                };
+                Ok(TypeAnnotatedValue::Handle(handle))
+            }
+            _ => Err(vec![
+                "Unexpected type; expected a Resource type.".to_string()
+            ]),
+        },
     }
 }
 
-impl From<&TypeAnnotatedValue> for AnalysedType {
-    fn from(value: &TypeAnnotatedValue) -> Self {
-        match value {
-            TypeAnnotatedValue::Bool(_) => AnalysedType::Bool,
-            TypeAnnotatedValue::S8(_) => AnalysedType::S8,
-            TypeAnnotatedValue::U8(_) => AnalysedType::U8,
-            TypeAnnotatedValue::S16(_) => AnalysedType::S16,
-            TypeAnnotatedValue::U16(_) => AnalysedType::U16,
-            TypeAnnotatedValue::S32(_) => AnalysedType::S32,
-            TypeAnnotatedValue::U32(_) => AnalysedType::U32,
-            TypeAnnotatedValue::S64(_) => AnalysedType::S64,
-            TypeAnnotatedValue::U64(_) => AnalysedType::U64,
-            TypeAnnotatedValue::F32(_) => AnalysedType::F32,
-            TypeAnnotatedValue::F64(_) => AnalysedType::F64,
-            TypeAnnotatedValue::Chr(_) => AnalysedType::Chr,
-            TypeAnnotatedValue::Str(_) => AnalysedType::Str,
-            TypeAnnotatedValue::List { typ, values: _ } => {
-                AnalysedType::List(Box::new(typ.clone()))
-            }
-            TypeAnnotatedValue::Tuple { typ, value: _ } => AnalysedType::Tuple(typ.clone()),
-            TypeAnnotatedValue::Record { typ, value: _ } => AnalysedType::Record(typ.clone()),
-            TypeAnnotatedValue::Flags { typ, values: _ } => AnalysedType::Flags(typ.clone()),
-            TypeAnnotatedValue::Enum { typ, value: _ } => AnalysedType::Enum(typ.clone()),
-            TypeAnnotatedValue::Option { typ, value: _ } => {
-                AnalysedType::Option(Box::new(typ.clone()))
-            }
-            TypeAnnotatedValue::Result {
-                ok,
-                error,
-                value: _,
-            } => AnalysedType::Result {
-                ok: ok.clone(),
-                error: error.clone(),
-            },
-            TypeAnnotatedValue::Handle {
-                id,
-                resource_mode,
-                uri: _,
-                resource_id: _,
-            } => AnalysedType::Resource {
-                id: id.clone(),
-                resource_mode: resource_mode.clone(),
-            },
-            TypeAnnotatedValue::Variant {
-                typ,
-                case_name: _,
-                case_value: _,
-            } => AnalysedType::Variant(typ.clone()),
-        }
+#[cfg(test)]
+mod tests {
+    use crate::protobuf::type_annotated_value::TypeAnnotatedValue;
+    use crate::protobuf::{r#type, PrimitiveType, TypePrimitive};
+    use crate::{create, Value};
+    use golem_wasm_ast::analysis::AnalysedType;
+
+    #[test]
+    fn test_type_annotated_value_from_analysed_type() {
+        let analysed_type = AnalysedType::U32;
+
+        let result = create(&Value::U32(1), &analysed_type);
+
+        let expected = TypeAnnotatedValue::U32(1);
+
+        assert_eq!(result, Ok(expected));
     }
-}
-impl TryFrom<TypeAnnotatedValue> for WitValue {
-    type Error = String;
-    fn try_from(value: TypeAnnotatedValue) -> Result<Self, Self::Error> {
-        let value: Result<Value, String> = value.try_into();
-        value.map(|v| v.into())
-    }
-}
 
-impl TryFrom<TypeAnnotatedValue> for Value {
-    type Error = String;
+    #[test]
+    fn test_type_annotated_value_from_type() {
+        let typ0 = r#type::Type::Primitive(TypePrimitive {
+            primitive: PrimitiveType::Bool as i32,
+        });
 
-    fn try_from(value: TypeAnnotatedValue) -> Result<Self, Self::Error> {
-        match value {
-            TypeAnnotatedValue::Bool(value) => Ok(Value::Bool(value)),
-            TypeAnnotatedValue::S8(value) => Ok(Value::S8(value)),
-            TypeAnnotatedValue::U8(value) => Ok(Value::U8(value)),
-            TypeAnnotatedValue::S16(value) => Ok(Value::S16(value)),
-            TypeAnnotatedValue::U16(value) => Ok(Value::U16(value)),
-            TypeAnnotatedValue::S32(value) => Ok(Value::S32(value)),
-            TypeAnnotatedValue::U32(value) => Ok(Value::U32(value)),
-            TypeAnnotatedValue::S64(value) => Ok(Value::S64(value)),
-            TypeAnnotatedValue::U64(value) => Ok(Value::U64(value)),
-            TypeAnnotatedValue::F32(value) => Ok(Value::F32(value)),
-            TypeAnnotatedValue::F64(value) => Ok(Value::F64(value)),
-            TypeAnnotatedValue::Chr(value) => Ok(Value::Char(value)),
-            TypeAnnotatedValue::Str(value) => Ok(Value::String(value)),
-            TypeAnnotatedValue::List { typ: _, values } => {
-                let mut list_values = Vec::new();
-                for value in values {
-                    match value.try_into() {
-                        Ok(v) => list_values.push(v),
-                        Err(err) => return Err(err),
-                    }
-                }
-                Ok(Value::List(list_values))
-            }
-            TypeAnnotatedValue::Tuple { typ: _, value } => {
-                let mut tuple_values = Vec::new();
-                for value in value {
-                    match value.try_into() {
-                        Ok(v) => tuple_values.push(v),
-                        Err(err) => return Err(err),
-                    }
-                }
-                Ok(Value::Tuple(tuple_values))
-            }
-            TypeAnnotatedValue::Record { typ: _, value } => {
-                let mut record_values = Vec::new();
-                for (_, value) in value {
-                    match value.try_into() {
-                        Ok(v) => record_values.push(v),
-                        Err(err) => return Err(err),
-                    }
-                }
-                Ok(Value::Record(record_values))
-            }
-            TypeAnnotatedValue::Flags { typ, values } => {
-                let mut bools = Vec::new();
+        let typ = crate::protobuf::Type { r#type: Some(typ0) };
 
-                for expected_flag in typ {
-                    if values.contains(&expected_flag) {
-                        bools.push(true);
-                    } else {
-                        bools.push(false);
-                    }
-                }
-                Ok(Value::Flags(bools))
-            }
-            TypeAnnotatedValue::Enum { typ, value } => typ
-                .iter()
-                .position(|expected_enum| expected_enum == &value)
-                .map(|index| Value::Enum(index as u32))
-                .ok_or_else(|| "Enum value not found in the list of expected enums".to_string()),
+        let result = create(&Value::U32(1), typ);
 
-            TypeAnnotatedValue::Option { typ: _, value } => match value {
-                Some(value) => {
-                    let value: Value = value.deref().clone().try_into()?;
-                    Ok(Value::Option(Some(Box::new(value))))
-                }
-                None => Ok(Value::Option(None)),
-            },
-            TypeAnnotatedValue::Result {
-                ok: _,
-                error: _,
-                value,
-            } => Ok(Value::Result(match value {
-                Ok(value) => match value {
-                    Some(v) => {
-                        let value: Value = v.deref().clone().try_into()?;
-                        Ok(Some(Box::new(value)))
-                    }
+        let expected = TypeAnnotatedValue::U32(1);
 
-                    None => Ok(None),
-                },
-                Err(value) => match value {
-                    Some(v) => {
-                        let value: Value = v.deref().clone().try_into()?;
-                        Err(Some(Box::new(value)))
-                    }
-
-                    None => Err(None),
-                },
-            })),
-            TypeAnnotatedValue::Handle {
-                id: _,
-                resource_mode: _,
-                uri,
-                resource_id,
-            } => Ok(Value::Handle { uri, resource_id }),
-            TypeAnnotatedValue::Variant {
-                typ,
-                case_name,
-                case_value,
-            } => match case_value {
-                Some(value) => {
-                    let result: Value = value.deref().clone().try_into()?;
-                    Ok(Value::Variant {
-                        case_idx: typ.iter().position(|(name, _)| name == &case_name).unwrap()
-                            as u32,
-                        case_value: Some(Box::new(result)),
-                    })
-                }
-                None => Ok(Value::Variant {
-                    case_idx: typ.iter().position(|(name, _)| name == &case_name).unwrap() as u32,
-                    case_value: None,
-                }),
-            },
-        }
+        assert_eq!(result, Ok(expected));
     }
 }


### PR DESCRIPTION
- Move TypeAnnotatedValue into protobuf. `TypeAnnotatedValue` reuses `Type` in protobuf  and thereore the type annotated in `TypeAnnotatedValue` is `Type` instead  of `AnalysedType`. 

- That said, we can still create a `TypeAnnotatedValue` given a `wasm_rpc::Value` and an `AnalysedType`.
   - The `type_annotated_value` module has a 1 single `create` function that takes `wasm_rpc::Value` and a type `T` as far as `T` can be converted to `Type`. Therefore `TypeAnnotatedValue` can be created given a `Value` and `Type` or `AnalysedType` as of now.
   
- With this change golem OSS can send `TypeAnnotatedValue` directly between services when needed, without any intermediate data transformations. Currently only `worker-bride` (gateway) ask this version of data from worker-executor when invoking a function, and almost all of the others get a `json::Value` (the protobuf version) with lesser payload size. See this PR: https://github.com/golemcloud/golem/pull/660

- Removal of unnecessary clones, and some functions became fallible due to the optional fields in `protobuf` generated types. I am uncomfortable "assuming" things here and doing any sort of `unwrap`, and therefore kept it as `Result` itself