### PR TITLE
build.rs: make wasm-ast root configurable with an env-var

### DIFF
--- a/wasm-rpc/build.rs
+++ b/wasm-rpc/build.rs
@@ -1,8 +1,9 @@
 use cargo_metadata::MetadataCommand;
+use std::env;
 use std::io::Result;
 
 fn main() -> Result<()> {
-    let wasm_ast_root = find_package_root("golem-wasm-ast");
+    let wasm_ast_root = env::var("GOLEM_WASM_AST_ROOT").unwrap_or_else(|_| find_package_root("golem-wasm-ast"));
 
     let mut config = prost_build::Config::new();
     config.extern_path(".wasm.ast", "::golem_wasm_ast::analysis::protobuf");


### PR DESCRIPTION
In a sandboxed build environment, `cargo metadata` tries to query crates.io. Even though I have been trying to pass `--offline` or `frozen`, I ran into an exception:
```
golem>   thread 'main' panicked at /build/cargo-vendor-dir/golem-wasm-rpc-1.0.2/build.rs:29:10:
golem>   called `Result::unwrap()` on an `Err` value: CargoMetadata { stderr: "warning: `/build/cargo-vendor-dir/.cargo/config` is deprecated in favor of `config.toml`
note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
warning: `/build/.cargo/config` is deprecated in favor of `config.toml`
note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
error: failed to get `arbitrary` as a dependency of package `golem-wasm-rpc v1.0.2 (/build/cargo-vendor-dir/golem-wasm-rpc-1.0.2)`

Caused by:
  failed to load source for dependency `arbitrary`
Caused by:
  Unable to update registry `crates-io`
Caused by:
  failed to update replaced source registry `crates-io`
Caused by:
  failed to read root of directory source: /build/cargo-vendor-dir/cargo-vendor-dir

Caused by:
  No such file or directory (os error 2)
" }
```
I want to propose a way to inject the location of the crate by setting an environment variable. If the environment variable is not set, we default to use `cargo metadata`

An analogous solution was implemented for golem-examples: 